### PR TITLE
feat: LAN transport over mDNS and TCP

### DIFF
--- a/.github/skills/native-boundary.md
+++ b/.github/skills/native-boundary.md
@@ -68,6 +68,7 @@ The modules:
 | ---------------------------- | --------------------- | ------------------------------ |
 | `NativeAirhopBLE.ts`         | `"AirhopBLE"`         | BLE peripheral and central I/O |
 | `NativeAirhopWiFi.ts`        | `"AirhopWiFi"`        | WiFi Aware fast path I/O       |
+| `NativeAirhopLAN.ts`         | `"AirhopLAN"`         | mDNS discovery and TCP links   |
 | `NativeAirhopWiFiPairing.ts` | `"AirhopWiFiPairing"` | iOS Wi-Fi Aware pairing sheet  |
 | `NativeAirhopVoice.ts`       | `"AirhopVoice"`       | AAC-LC capture and playback    |
 | `NativeAirhopTor.ts`         | `"AirhopTor"`         | Tor lifecycle (Arti / Orbot)   |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,31 +25,32 @@ You must read these four documents before making any code suggestions:
 
 ## Where Things Live
 
-| Thing                                                         | Location                   |
-| ------------------------------------------------------------- | -------------------------- |
-| Crypto (Noise XX, identity, DR)                               | `src/core/crypto/`         |
-| Wire format: the packet frame and every payload               | `src/core/mesh/wire/`      |
-| Mesh routing, dedup, fragmentation, source routes             | `src/core/mesh/routing/`   |
-| Open links per radio, and the writes that go down them        | `src/core/mesh/links/`     |
-| GCS gossip sync                                               | `src/core/mesh/sync/`      |
-| Announces and nickname normalisation                          | `src/core/mesh/discovery/` |
-| Private-channel and private-group crypto                      | `src/core/mesh/rooms/`     |
-| Store-and-forward envelopes and one-time prekeys              | `src/core/mesh/courier/`   |
-| Live push-to-talk capture and playback                        | `src/core/mesh/voice/`     |
-| Nostr (client, gift-wrap, geo-relay, presence, courier-relay) | `src/core/nostr/`          |
-| Payments: tokens, DLEQ, NIP-61, seed (pure)                   | `src/core/payments/`       |
-| Payments: anything touching a mint                            | `src/services/`            |
-| Screen logic                                                  | `src/features/`            |
-| UI components, hooks, theme tokens                            | `src/ui/`                  |
-| Thin wrappers over OS APIs (permissions, haptics)             | `src/platform/`            |
-| State management                                              | `src/store/`               |
-| UI copy: the catalog, the runtime, RTL helpers                | `src/i18n/`                |
-| TurboModule specs (Codegen input)                             | `src/bridge/`              |
-| Root component and tab state machine                          | `src/app/`                 |
-| Whole-app lifecycle and simulation suites                     | `src/__tests__/`           |
-| iOS native                                                    | `ios/`                     |
-| Android native                                                | `android/`                 |
-| All protocol constants                                        | `docs/spec/PROTOCOLS.md`   |
+| Thing                                                         | Location                          |
+| ------------------------------------------------------------- | --------------------------------- |
+| Crypto (Noise XX, identity, DR)                               | `src/core/crypto/`                |
+| Wire format: the packet frame and every payload               | `src/core/mesh/wire/`             |
+| Mesh routing, dedup, fragmentation, source routes             | `src/core/mesh/routing/`          |
+| Open links per radio, and the writes that go down them        | `src/core/mesh/links/`            |
+| Which peers the LAN transport dials, and the cap on it        | `src/services/lan-dial-policy.ts` |
+| GCS gossip sync                                               | `src/core/mesh/sync/`             |
+| Announces and nickname normalisation                          | `src/core/mesh/discovery/`        |
+| Private-channel and private-group crypto                      | `src/core/mesh/rooms/`            |
+| Store-and-forward envelopes and one-time prekeys              | `src/core/mesh/courier/`          |
+| Live push-to-talk capture and playback                        | `src/core/mesh/voice/`            |
+| Nostr (client, gift-wrap, geo-relay, presence, courier-relay) | `src/core/nostr/`                 |
+| Payments: tokens, DLEQ, NIP-61, seed (pure)                   | `src/core/payments/`              |
+| Payments: anything touching a mint                            | `src/services/`                   |
+| Screen logic                                                  | `src/features/`                   |
+| UI components, hooks, theme tokens                            | `src/ui/`                         |
+| Thin wrappers over OS APIs (permissions, haptics)             | `src/platform/`                   |
+| State management                                              | `src/store/`                      |
+| UI copy: the catalog, the runtime, RTL helpers                | `src/i18n/`                       |
+| TurboModule specs (Codegen input)                             | `src/bridge/`                     |
+| Root component and tab state machine                          | `src/app/`                        |
+| Whole-app lifecycle and simulation suites                     | `src/__tests__/`                  |
+| iOS native                                                    | `ios/`                            |
+| Android native                                                | `android/`                        |
+| All protocol constants                                        | `docs/spec/PROTOCOLS.md`          |
 
 ## Rules Every Agent Must Follow
 

--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ I built this at a 24-hour hackathon (July 2026) during my final year of undergra
 |                   | Panic wipe                | Triple-tap instantly erases keys and local messages (nuke your account)                                                                      |
 | 🕸️ **Networking** | Bluetooth mesh            | Communicate with nearby devices without internet                                                                                             |
 |                   | LAN mesh                  | Run the whole mesh over a shared WiFi network, discovered by mDNS. Works iPhone to Android, unlike WiFi Aware                                |
-|                   | Mesh bridge               | Link this area's public #bluetooth chat with another out-of-range Bluetooth crowd over the internet. Off by default                          |
+|                   | Mesh bridge               | Link this area's public #bluetooth chat with another out-of-range Bluetooth crowd over the internet                                          |
 |                   | WiFi Aware                | Faster file transfers between two Android devices, or two iPhones. Not across platforms                                                      |
 |                   | Multi-hop routing         | Messages automatically relay across nearby devices (up to 7 hops)                                                                            |
 |                   | Relay nodes               | Third-party [Bitle](https://bitle.org) hardware extends the mesh where nobody stands. Requires an ESP32 board, plus LoRa to link nodes       |
 |                   | bitchat compatibility     | Airhop nodes communicate directly with bitchat on iOS and Android                                                                            |
 | 🌐 **Internet**   | Internet fallback         | DMs and channels keep flowing over Nostr relays when a user moves out of Bluetooth range                                                     |
 |                   | Geo-relay discovery       | Discover location-based channels across 300+ distributed Nostr relays                                                                        |
-|                   | Internet gateway          | Lend your connection to a nearby offline phone so it can still reach the location (geohash) channels. Off by default                         |
+|                   | Internet gateway          | Lend your connection to a nearby offline phone so it can still reach the location (geohash) channels                                         |
 |                   | Tor integration           | Route Nostr traffic through Tor (Arti on iOS, Orbot on Android)                                                                              |
 
 ## Optional Features

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -39,6 +39,12 @@
        so it is granted on install with nothing for the user to answer. -->
   <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
+  <!-- Lets the LAN transport hold a MulticastLock. WiFi power save drops
+       multicast when the screen goes off, and mDNS is multicast, so without
+       this the transport finds peers while somebody is looking at the phone and
+       silently stops finding them the moment it is pocketed. Normal protection
+       level, granted on install. -->
+  <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
   <!-- Required for Android 14+ to keep BLE active in a foreground service -->
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE"/>

--- a/android/app/src/main/java/org/onemindlabs/airhop/MainApplication.kt
+++ b/android/app/src/main/java/org/onemindlabs/airhop/MainApplication.kt
@@ -15,6 +15,7 @@ import expo.modules.ApplicationLifecycleDispatcher
 import expo.modules.ExpoReactHostFactory
 import org.onemindlabs.airhop.app.AirhopAppPackage
 import org.onemindlabs.airhop.ble.AirhopBLEPackage
+import org.onemindlabs.airhop.lan.AirhopLANPackage
 import org.onemindlabs.airhop.voice.AirhopVoicePackage
 import org.onemindlabs.airhop.wifi.AirhopWiFiPackage
 
@@ -27,6 +28,7 @@ class MainApplication : Application(), ReactApplication {
         PackageList(this).packages.apply {
           add(AirhopBLEPackage())
           add(AirhopWiFiPackage())
+          add(AirhopLANPackage())
           add(AirhopVoicePackage())
           add(AirhopAppPackage())
         }

--- a/android/app/src/main/java/org/onemindlabs/airhop/lan/AirhopLANModule.kt
+++ b/android/app/src/main/java/org/onemindlabs/airhop/lan/AirhopLANModule.kt
@@ -1,0 +1,621 @@
+package org.onemindlabs.airhop.lan
+
+// The LAN transport: mDNS discovery over ordinary TCP.
+//
+// The only transport that reaches an iPhone from an Android phone over
+// something other than Bluetooth. WiFi Aware cannot, because Apple demands a
+// paired data path Android has no way to complete. This is plain IP, so it does
+// not care which phone anyone owns.
+//
+// Framing, the accept loop, the read loop and the link registry are the same
+// shapes AirhopWiFiModule uses, deliberately: both carry the same length-
+// prefixed Airhop packets, so a bug fixed in one is recognisable in the other.
+// What differs is above the socket. Aware connects to whatever it finds; this
+// connects only where it is told to, because mDNS returns everyone and
+// connecting to everyone is a full mesh. That decision lives in TypeScript
+// (services/lan-dial-policy.ts).
+//
+// The instance name comes from TypeScript and is never the peer ID. See
+// services/lan-controller.ts for why it rotates.
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.net.ConnectivityManager
+import android.net.nsd.NsdManager
+import android.net.nsd.NsdServiceInfo
+import android.net.wifi.WifiManager
+import android.os.Build
+import android.util.Base64
+import android.util.Log
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.WritableNativeMap
+import com.facebook.react.modules.core.DeviceEventManagerModule
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+private const val TAG = "AirhopLANModule"
+
+// The service type every Airhop device publishes and browses for. Matches the
+// `NSBonjourServices` entry in the iOS Info.plist byte for byte; a mismatch is
+// two apps that cannot see each other.
+//
+// Not Wi-Fi Aware's `_airhop-mesh-v1._tcp`. Two services, named apart so neither
+// reads as a typo of the other: Aware is a radio protocol needing no network,
+// this is mDNS over an ordinary one.
+private const val SERVICE_TYPE = "_airhop-lan-v1._tcp"
+
+private const val EVT_PEER_DISCOVERED = "AirhopLAN.peerDiscovered"
+private const val EVT_PEER_LOST = "AirhopLAN.peerLost"
+private const val EVT_LINK_CONNECTED = "AirhopLAN.linkConnected"
+private const val EVT_LINK_DISCONNECTED = "AirhopLAN.linkDisconnected"
+private const val EVT_PACKET_RECEIVED = "AirhopLAN.packetReceived"
+private const val EVT_AVAILABILITY_CHANGED = "AirhopLAN.availabilityChanged"
+
+// Matches AirhopWiFiModule and the iOS side: 64 KiB of payload plus the prefix.
+private const val MAX_FRAME = 65544
+
+// A read deadline is what turns a half-open link into a closed one. Without it
+// a socket whose far side vanished without a FIN sits in `links` until a write
+// happens to fail, and the courier counts links to decide whether it has anyone
+// to hand mail to. Same value and same reason as the WiFi module.
+private const val READ_TIMEOUT_MS = 90_000
+private const val MAX_IDLE_TIMEOUTS = 3
+
+// How long to wait for a dial before giving up. Client isolation, which most
+// guest networks enable, shows up here as a connect that never completes rather
+// than as a refusal, so an unbounded connect would hold a thread forever.
+private const val CONNECT_TIMEOUT_MS = 5_000
+
+class AirhopLANModule(
+    private val reactContext: ReactApplicationContext,
+) : ReactContextBaseJavaModule(reactContext) {
+
+    override fun getName(): String = "AirhopLAN"
+
+    // Resolved per call, never cached: a service not yet ready when the module
+    // is constructed would otherwise latch null for the life of the process.
+    // Same reasoning as AirhopWiFiModule.awareManager().
+    private fun nsdManager(): NsdManager? =
+        try {
+            reactContext.applicationContext.getSystemService(NsdManager::class.java)
+        } catch (_: Exception) {
+            null
+        }
+
+    private fun wifiManager(): WifiManager? =
+        try {
+            reactContext.applicationContext.getSystemService(WifiManager::class.java)
+        } catch (_: Exception) {
+            null
+        }
+
+    private val ioExecutor = Executors.newCachedThreadPool()
+    private val linkCounter = AtomicInteger(0)
+
+    private class LinkState(
+        val id: String,
+        val socket: Socket,
+        val output: OutputStream,
+        val writeLock: Any = Any(),
+    )
+
+    private val links = ConcurrentHashMap<String, LinkState>()
+
+    // Peers mDNS has resolved, keyed by the name they publish. Held because a
+    // dial arrives from TypeScript naming a peer, not an address.
+    private class Resolved(val host: InetAddress, val port: Int)
+
+    private val discovered = ConcurrentHashMap<String, Resolved>()
+
+    // Which peer each open link belongs to, and the reverse.
+    //
+    // Held so a repeat dial for a peer already linked can resolve without
+    // opening a second socket. TypeScript walks its dial plan on a timer, since
+    // a link can drop while the peer's mDNS record stays visible, and it does
+    // not track which names are linked: that is this module's knowledge.
+    private val linkByName = ConcurrentHashMap<String, String>()
+    private val nameByLink = ConcurrentHashMap<String, String>()
+
+    private var serverSocket: ServerSocket? = null
+    private var serverPort: Int = 0
+    private var instanceName: String? = null
+
+    private var registrationListener: NsdManager.RegistrationListener? = null
+    private var discoveryListener: NsdManager.DiscoveryListener? = null
+    private var networkReceiver: BroadcastReceiver? = null
+
+    // Multicast is dropped by WiFi power save unless something holds this lock,
+    // which is why the app can find peers while the screen is on and silently
+    // stops the moment it is off. Held for as long as the transport runs.
+    private var multicastLock: WifiManager.MulticastLock? = null
+
+    // Resolves run one at a time below API 34.
+    //
+    // NsdManager.resolveService is documented as one outstanding resolve per
+    // manager, and issuing a second while the first is in flight fails both with
+    // FAILURE_ALREADY_ACTIVE. mDNS answers arrive as a burst, one per device, so
+    // this is the ordinary case rather than a race. API 34 added
+    // registerServiceInfoCallback, which has no such limit, but the floor here
+    // is lower than that.
+    private val resolveQueue = ArrayDeque<NsdServiceInfo>()
+    private var resolving = false
+    private val resolveLock = Any()
+
+    // ---- Lifecycle -----------------------------------------------------------
+
+    @ReactMethod
+    fun startLAN(instanceName: String, promise: Promise) {
+        val nsd = nsdManager()
+        if (nsd == null) {
+            promise.reject("LAN_UNSUPPORTED", "This device has no mDNS service")
+            return
+        }
+        if (this.instanceName != null) {
+            // Already running under some name. Idempotent, as the reconciler
+            // expects: it calls start whenever it is unsure.
+            promise.resolve(null)
+            return
+        }
+        if (!hasNetwork()) {
+            promise.reject("LAN_UNAVAILABLE", "No network to publish on")
+            return
+        }
+        if (!ensureServerSocket()) {
+            promise.reject("LAN_LISTEN_FAILED", "Could not open the LAN server socket")
+            return
+        }
+
+        this.instanceName = instanceName
+        acquireMulticastLock()
+        registerNetworkReceiver()
+
+        try {
+            registerService(nsd, instanceName)
+            startDiscovery(nsd)
+        } catch (e: SecurityException) {
+            // Android 16 opts in and Android 17 enforces ACCESS_LOCAL_NETWORK.
+            // A refusal here is the user's answer, not a fault, and it clears
+            // if they grant it later.
+            teardown()
+            promise.reject("PERMISSION_DENIED", "Local network access refused", e)
+            return
+        } catch (e: Exception) {
+            teardown()
+            promise.reject("LAN_LISTEN_FAILED", e.message, e)
+            return
+        }
+        promise.resolve(null)
+    }
+
+    @ReactMethod
+    fun stopLAN(promise: Promise) {
+        teardown()
+        promise.resolve(null)
+    }
+
+    private fun teardown() {
+        val nsd = nsdManager()
+        registrationListener?.let { runCatching { nsd?.unregisterService(it) } }
+        registrationListener = null
+        discoveryListener?.let { runCatching { nsd?.stopServiceDiscovery(it) } }
+        discoveryListener = null
+
+        networkReceiver?.let { runCatching { reactContext.unregisterReceiver(it) } }
+        networkReceiver = null
+
+        multicastLock?.let { runCatching { if (it.isHeld) it.release() } }
+        multicastLock = null
+
+        runCatching { serverSocket?.close() }
+        serverSocket = null
+        serverPort = 0
+        instanceName = null
+
+        for (id in links.keys.toList()) handleLinkClose(id)
+        links.clear()
+        discovered.clear()
+        linkByName.clear()
+        nameByLink.clear()
+        synchronized(resolveLock) {
+            resolveQueue.clear()
+            resolving = false
+        }
+    }
+
+    private fun hasNetwork(): Boolean =
+        try {
+            val cm = reactContext.applicationContext
+                .getSystemService(ConnectivityManager::class.java)
+            cm?.activeNetwork != null
+        } catch (_: Exception) {
+            false
+        }
+
+    private fun acquireMulticastLock() {
+        if (multicastLock != null) return
+        multicastLock = try {
+            wifiManager()?.createMulticastLock("airhop-lan")?.apply {
+                setReferenceCounted(false)
+                acquire()
+            }
+        } catch (e: Exception) {
+            // Not fatal. Discovery still works with the screen on, which is
+            // when most of it happens, so a missing lock is a degradation
+            // rather than a reason to refuse the transport.
+            Log.w(TAG, "No multicast lock: ${e.message}")
+            null
+        }
+    }
+
+    // The interface going away is the case that is otherwise unrecoverable: the
+    // listener and the browser are dead while this module still believes it is
+    // running, so every later start resolves instantly having done nothing.
+    private fun registerNetworkReceiver() {
+        if (networkReceiver != null) return
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                emitEvent(
+                    EVT_AVAILABILITY_CHANGED,
+                    WritableNativeMap().apply { putBoolean("available", hasNetwork()) },
+                )
+            }
+        }
+        val filter = IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                reactContext.registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
+            } else {
+                @Suppress("UnspecifiedRegisterReceiverFlag")
+                reactContext.registerReceiver(receiver, filter)
+            }
+            networkReceiver = receiver
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not watch the network state: ${e.message}")
+        }
+    }
+
+    // ---- Discovery -----------------------------------------------------------
+
+    private fun registerService(nsd: NsdManager, name: String) {
+        val info = NsdServiceInfo().apply {
+            serviceName = name
+            serviceType = SERVICE_TYPE
+            port = serverPort
+        }
+        val listener = object : NsdManager.RegistrationListener {
+            override fun onServiceRegistered(info: NsdServiceInfo) {
+                Log.d(TAG, "Published as ${info.serviceName}")
+            }
+
+            override fun onRegistrationFailed(info: NsdServiceInfo, errorCode: Int) {
+                Log.e(TAG, "Publish refused: $errorCode")
+            }
+
+            override fun onServiceUnregistered(info: NsdServiceInfo) = Unit
+            override fun onUnregistrationFailed(info: NsdServiceInfo, errorCode: Int) = Unit
+        }
+        registrationListener = listener
+        nsd.registerService(info, NsdManager.PROTOCOL_DNS_SD, listener)
+    }
+
+    private fun startDiscovery(nsd: NsdManager) {
+        val listener = object : NsdManager.DiscoveryListener {
+            override fun onDiscoveryStarted(serviceType: String) = Unit
+
+            override fun onServiceFound(info: NsdServiceInfo) {
+                // Our own record comes back off the network like anyone else's.
+                if (info.serviceName == instanceName) return
+                enqueueResolve(info)
+            }
+
+            override fun onServiceLost(info: NsdServiceInfo) {
+                discovered.remove(info.serviceName)
+                emitEvent(
+                    EVT_PEER_LOST,
+                    WritableNativeMap().apply { putString("serviceName", info.serviceName) },
+                )
+            }
+
+            override fun onDiscoveryStopped(serviceType: String) = Unit
+
+            override fun onStartDiscoveryFailed(serviceType: String, errorCode: Int) {
+                Log.e(TAG, "Browse refused: $errorCode")
+                emitEvent(
+                    EVT_AVAILABILITY_CHANGED,
+                    WritableNativeMap().apply { putBoolean("available", false) },
+                )
+            }
+
+            override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) = Unit
+        }
+        discoveryListener = listener
+        nsd.discoverServices(SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, listener)
+    }
+
+    private fun enqueueResolve(info: NsdServiceInfo) {
+        synchronized(resolveLock) {
+            resolveQueue.addLast(info)
+            if (resolving) return
+            resolving = true
+        }
+        drainResolves()
+    }
+
+    private fun drainResolves() {
+        val next = synchronized(resolveLock) {
+            val head = resolveQueue.removeFirstOrNull()
+            if (head == null) resolving = false
+            head
+        } ?: return
+
+        val nsd = nsdManager()
+        if (nsd == null) {
+            synchronized(resolveLock) { resolving = false }
+            return
+        }
+
+        @Suppress("DEPRECATION")
+        nsd.resolveService(
+            next,
+            object : NsdManager.ResolveListener {
+                override fun onResolveFailed(info: NsdServiceInfo, errorCode: Int) {
+                    Log.d(TAG, "Resolve failed for ${info.serviceName}: $errorCode")
+                    drainResolves()
+                }
+
+                override fun onServiceResolved(info: NsdServiceInfo) {
+                    val host = info.host
+                    if (host != null && info.serviceName != instanceName) {
+                        discovered[info.serviceName] = Resolved(host, info.port)
+                        // The name only. The address stays here, in
+                        // `discovered`, because it is this module's business to
+                        // dial and nobody above needs it.
+                        emitEvent(
+                            EVT_PEER_DISCOVERED,
+                            WritableNativeMap().apply {
+                                putString("serviceName", info.serviceName)
+                            },
+                        )
+                    }
+                    drainResolves()
+                }
+            },
+        )
+    }
+
+    // ---- Links ---------------------------------------------------------------
+
+    @ReactMethod
+    fun connectToPeer(serviceName: String, promise: Promise) {
+        val peer = discovered[serviceName]
+        if (peer == null) {
+            promise.reject("UNKNOWN_PEER", "No resolved peer named $serviceName")
+            return
+        }
+        // Idempotent. The caller re-walks its plan on a timer to heal a dropped
+        // link, and asking for one that is already up must cost a resolve, not
+        // a second socket.
+        val existing = linkByName[serviceName]
+        if (existing != null && links.containsKey(existing)) {
+            promise.resolve(null)
+            return
+        }
+        try {
+            ioExecutor.execute {
+                try {
+                    val socket = Socket()
+                    socket.connect(
+                        java.net.InetSocketAddress(peer.host, peer.port),
+                        CONNECT_TIMEOUT_MS,
+                    )
+                    registerLink(
+                        "lan-out-${linkCounter.incrementAndGet()}",
+                        socket,
+                        serviceName,
+                    )
+                    promise.resolve(null)
+                } catch (e: Exception) {
+                    // Most often client isolation, which every guest network
+                    // enables and which cannot be detected before trying.
+                    Log.d(TAG, "Dial to $serviceName failed: ${e.message}")
+                    promise.reject("CONNECT_FAILED", e.message, e)
+                }
+            }
+        } catch (e: Exception) {
+            promise.reject("CONNECT_FAILED", "LAN transport is shutting down", e)
+        }
+    }
+
+    private fun ensureServerSocket(): Boolean {
+        if (serverSocket != null) return true
+        return try {
+            val socket = ServerSocket(0)
+            serverSocket = socket
+            serverPort = socket.localPort
+            ioExecutor.execute { acceptLoop(socket) }
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "Could not open the LAN server socket: ${e.message}")
+            false
+        }
+    }
+
+    private fun acceptLoop(socket: ServerSocket) {
+        while (!socket.isClosed) {
+            val client = try {
+                socket.accept()
+            } catch (e: Exception) {
+                Log.d(TAG, "Accept loop ended: ${e.message}")
+                return
+            }
+            registerLink("lan-in-${linkCounter.incrementAndGet()}", client)
+        }
+    }
+
+    // `serviceName` is known only for a dial we made. An accepted connection is
+    // anonymous until its peer announces, and nothing here needs to know: the
+    // name is used solely to answer "already connected" for an outbound dial.
+    private fun registerLink(id: String, socket: Socket, serviceName: String? = null) {
+        try {
+            socket.tcpNoDelay = true
+            socket.soTimeout = READ_TIMEOUT_MS
+            val output = socket.getOutputStream()
+            links[id] = LinkState(id, socket, output)
+            if (serviceName != null) {
+                linkByName[serviceName] = id
+                nameByLink[id] = serviceName
+            }
+            emitEvent(EVT_LINK_CONNECTED, WritableNativeMap().apply { putString("linkID", id) })
+            Log.d(TAG, "LAN link connected: $id")
+            startReadLoop(id, socket.getInputStream())
+        } catch (e: Exception) {
+            Log.e(TAG, "Could not register link $id: ${e.message}")
+            runCatching { socket.close() }
+        }
+    }
+
+    @ReactMethod
+    fun writeToLANLink(linkID: String, dataBase64: String, promise: Promise) {
+        val link = links[linkID]
+        if (link == null) {
+            promise.reject("UNKNOWN_LINK", "No active LAN link: $linkID")
+            return
+        }
+        val data = try {
+            Base64.decode(dataBase64, Base64.NO_WRAP)
+        } catch (e: Exception) {
+            promise.reject("INVALID_DATA", "Invalid base64 payload", e)
+            return
+        }
+        if (data.size > MAX_FRAME - 4) {
+            promise.reject("FRAME_TOO_LARGE", "Frame of ${data.size} exceeds the peer's read limit")
+            return
+        }
+        try {
+            ioExecutor.execute {
+                try {
+                    val frame = ByteArray(4 + data.size)
+                    val len = data.size
+                    frame[0] = (len shr 24).toByte()
+                    frame[1] = (len shr 16).toByte()
+                    frame[2] = (len shr 8).toByte()
+                    frame[3] = len.toByte()
+                    data.copyInto(frame, 4)
+                    synchronized(link.writeLock) {
+                        link.output.write(frame)
+                        link.output.flush()
+                    }
+                    promise.resolve(null)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Write failed on $linkID: ${e.message}")
+                    handleLinkClose(linkID)
+                    promise.reject("WRITE_FAILED", e.message, e)
+                }
+            }
+        } catch (e: Exception) {
+            promise.reject("LINK_CLOSED", "LAN transport is shutting down", e)
+        }
+    }
+
+    private fun startReadLoop(linkID: String, input: InputStream) {
+        ioExecutor.execute {
+            val lenBuf = ByteArray(4)
+            var idleTimeouts = 0
+            while (true) {
+                try {
+                    var read = 0
+                    while (read < 4) {
+                        val n = input.read(lenBuf, read, 4 - read)
+                        if (n < 0) throw java.io.EOFException("EOF in length prefix")
+                        read += n
+                    }
+                    val len = ((lenBuf[0].toInt() and 0xff) shl 24) or
+                        ((lenBuf[1].toInt() and 0xff) shl 16) or
+                        ((lenBuf[2].toInt() and 0xff) shl 8) or
+                        (lenBuf[3].toInt() and 0xff)
+                    if (len <= 0 || len > MAX_FRAME) {
+                        throw Exception("LAN link $linkID: invalid frame length $len")
+                    }
+                    val payload = ByteArray(len)
+                    var got = 0
+                    while (got < len) {
+                        val n = input.read(payload, got, len - got)
+                        if (n < 0) throw java.io.EOFException("EOF in payload")
+                        got += n
+                    }
+                    idleTimeouts = 0
+                    emitEvent(
+                        EVT_PACKET_RECEIVED,
+                        WritableNativeMap().apply {
+                            putString("linkID", linkID)
+                            putString("dataBase64", Base64.encodeToString(payload, Base64.NO_WRAP))
+                        },
+                    )
+                } catch (e: java.net.SocketTimeoutException) {
+                    // A quiet link is not a dead one. Only a run of deadlines
+                    // with nothing in between says the far side is gone.
+                    idleTimeouts++
+                    if (idleTimeouts >= MAX_IDLE_TIMEOUTS) {
+                        Log.d(TAG, "Link $linkID idle past the deadline, closing")
+                        handleLinkClose(linkID)
+                        return@execute
+                    }
+                } catch (e: Exception) {
+                    Log.d(TAG, "Read loop ended for $linkID: ${e.message}")
+                    handleLinkClose(linkID)
+                    return@execute
+                }
+            }
+        }
+    }
+
+    private fun handleLinkClose(linkID: String) {
+        val link = links.remove(linkID) ?: return
+        val name = nameByLink.remove(linkID)
+        // Only if it still points here: a newer link may have claimed the name,
+        // and clearing it would make the live one look absent.
+        if (name != null && linkByName[name] == linkID) linkByName.remove(name)
+        runCatching { link.socket.close() }
+        emitEvent(EVT_LINK_DISCONNECTED, WritableNativeMap().apply { putString("linkID", linkID) })
+    }
+
+    // ---- Required NativeEventEmitter contract --------------------------------
+
+    @ReactMethod
+    fun addListener(@Suppress("UNUSED_PARAMETER") eventName: String) {
+        // Subscriptions are tracked on the JS side.
+    }
+
+    @ReactMethod
+    fun removeListeners(@Suppress("UNUSED_PARAMETER") count: Double) {
+        // Subscriptions are tracked on the JS side.
+    }
+
+    override fun invalidate() {
+        teardown()
+        ioExecutor.shutdownNow()
+        super.invalidate()
+    }
+
+    private fun emitEvent(name: String, params: WritableNativeMap) {
+        if (!reactContext.hasActiveReactInstance()) return
+        try {
+            reactContext
+                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+                .emit(name, params)
+        } catch (e: Exception) {
+            Log.w(TAG, "Dropped $name: no JS runtime to receive it (${e.message})")
+        }
+    }
+}

--- a/android/app/src/main/java/org/onemindlabs/airhop/lan/AirhopLANPackage.kt
+++ b/android/app/src/main/java/org/onemindlabs/airhop/lan/AirhopLANPackage.kt
@@ -1,0 +1,28 @@
+// Registers AirhopLANModule with the React Native bridge.
+// Referenced from MainApplication.kt's getPackages() list alongside AirhopBLEPackage.
+package org.onemindlabs.airhop.lan
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class AirhopLANPackage : ReactPackage {
+
+    // ReactPackage.createNativeModules is deprecated in New Architecture (use codegen TurboModules),
+    // but legacy interop still requires it until AirhopLANModule is fully migrated.
+    //
+    // No API gate, unlike the WiFi package: NsdManager has been available since
+    // API 16, well below this app's floor. The module reports its own
+    // unavailability instead, since a device with mDNS can still be on no
+    // network at all.
+    @Suppress("OVERRIDE_DEPRECATION")
+    override fun createNativeModules(
+        reactContext: ReactApplicationContext,
+    ): List<NativeModule> = listOf(AirhopLANModule(reactContext))
+
+    @Suppress("OVERRIDE_DEPRECATION")
+    override fun createViewManagers(
+        reactContext: ReactApplicationContext,
+    ): List<ViewManager<*, *>> = emptyList()
+}

--- a/docs/design/ROADMAP.md
+++ b/docs/design/ROADMAP.md
@@ -4,8 +4,6 @@
 
 ## 1. Where Airhop Fits: Gap Analysis vs bitchat
 
-bitchat is an excellent foundation. Airhop fills the gaps it left open.
-
 ### Gap 1: Unified Codebase
 
 **bitchat problem:** iOS and Android are separate native codebases that drift. The Android v0.7 fragment size mismatch (500B vs 150B) broke iOS-Android compatibility for months with no one noticing.  
@@ -44,7 +42,7 @@ bitchat is an excellent foundation. Airhop fills the gaps it left open.
 │                                                                             │
 │  ┌─────────────────────────────────────────────────────────────────────┐    │
 │  │              MESSAGE ROUTER (TypeScript)                            │    │
-│  │  canDeliverPromptly() -> both radios -> Nostr -> courier            │    │
+│  │  canDeliverPromptly() -> every link -> Nostr -> courier             │    │
 │  │  -> Courier envelope (store-and-forward) -> Double Ratchet step     │    │
 │  └──────────────────────────────┬──────────────────────────────────────┘    │
 │                                 │                                           │
@@ -54,16 +52,16 @@ bitchat is an excellent foundation. Airhop fills the gaps it left open.
 │  └──────────┬─────────────────────────────────────┬────────────────────┘    │
 │             │                                     │                         │
 │  ┌──────────▼──────────────────┐     ┌────────────▼───────────────────┐     │
-│  │   BLE MESH ENGINE (TS)      │     │   NOSTR TRANSPORT (TS)         │     │
+│  │   MESH ENGINE (TS)          │     │   NOSTR TRANSPORT (TS)         │     │
 │  │  PacketCodec, TTL flood     │     │  nostr-tools NIP-17/59         │     │
 │  │  GossipSync (GCS filter)    │     │  SimplePool -> 300+ relays     │     │
 │  │  CourierStore, Fragments    │     │  GeoRelayDirectory, Tor proxy  │     │
 │  └──────────┬──────────────────┘     └────────────────────────────────┘     │
 │             │ JSI TurboModule                                               │
 │  ┌──────────▼──────────────────────────────────────────────────────────┐    │
-│  │              AIRHOP NATIVE BLE MODULE                               │    │
-│  │  iOS: CBPeripheralManager + CBCentralManager (Swift)                │    │
-│  │  Android: BluetoothGattServer + BluetoothLeScanner (Kotlin)         │    │
+│  │           AIRHOP NATIVE TRANSPORT MODULES                           │    │
+│  │  BLE: CBCentral/CBPeripheral (Swift), BluetoothGatt (Kotlin)        │    │
+│  │  LAN: NWListener/NWBrowser (Swift), NsdManager (Kotlin)             │    │
 │  └─────────────────────────────────────────────────────────────────────┘    │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```

--- a/docs/dev/PROGRESS.md
+++ b/docs/dev/PROGRESS.md
@@ -65,6 +65,7 @@ checkable against the code rather than taken on trust.
 - [x] `src/core/mesh/routing/flood-router.ts`: TTL flood, jitter, dedup
 - [x] `src/core/mesh/routing/deduplicator.ts`: LRU 1000-entry seen-set
 - [x] `src/core/mesh/links/link-registry.ts`: open links per radio, peer bindings, writes
+- [x] `src/services/lan-dial-policy.ts`: the ring that caps LAN at 8 links per phone
 - [x] `src/core/mesh/discovery/announce-manager.ts`: signed presence broadcasts
 - [x] `src/core/crypto/identity.ts`: key generation, Keychain storage, peer ID
 

--- a/docs/spec/ARCHITECTURE.md
+++ b/docs/spec/ARCHITECTURE.md
@@ -237,19 +237,47 @@ anywhere with WiFi and no route out.
 
 mDNS discovery on `_airhop-lan-v1._tcp` plus TCP links closes it. The links carry
 the same packet frames BLE carries, so the mesh engine needs no new concept and
-the wire format does not move. Being ordinary IP, it is platform-neutral, and
-it carries the whole mesh rather than only the parts Nostr can express.
-Tracked in [#38](https://github.com/areebahmeddd/airhop/issues/38).
+the wire format does not move. It sits beside WiFi Aware rather than replacing
+it: Aware needs no network at all, which mDNS cannot do, and mDNS reaches
+everyone on a network, which Aware cannot. The service name is kept apart from
+Aware's `_airhop-mesh-v1._tcp` so neither reads as a typo of the other.
 
-It sits beside WiFi Aware rather than replacing it. Aware needs no network at
-all, which mDNS structurally cannot do; mDNS reaches everyone on a network,
-which Aware cannot. Neither is a superset of the other.
+Two decisions are unique to it.
 
-| Constraint       | Consequence                                                                                                                                                                       |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Client isolation | Most guest and venue WiFi blocks peer-to-peer traffic at the access point, and it cannot be detected before trying. The UI has to say "no peers on this network" rather than spin |
-| mDNS filtering   | Common even where ordinary traffic works. A manual join by address covers it                                                                                                      |
-| iOS background   | A TCP socket has no equivalent of `bluetooth-central`, so a locked iPhone drops the link. A foreground accelerator, which WiFi Aware already is on iOS                            |
+**Who to connect to.** Bluetooth answers this with physics: the radio holds six
+or so links and refuses more. mDNS returns the whole network, and taking all of
+it is quadratic. Thirty phones fully connected is 435 sockets, and one broadcast
+costs 841 writes instead of 29 because every phone relays to everyone it holds
+and the deduplicator discards the copies; a channel photo turns that into
+millions of writes for one file. The arithmetic is not LAN's. Bluetooth is saved
+from it only by the radio refusing the links.
+
+So LAN caps at 8, sized against bitchat's `bleMaxCentralLinks` of 6, which keeps
+a LAN room reading the way a Bluetooth room does to every constant tuned for
+Bluetooth density. Names are sorted into one ring and a device links to the four
+either side of it, dialling only those sorting after its own so no pair is
+dialled twice. Both ends compute the same ring, so they agree without
+negotiating, and below the cap the ring wraps and everyone is a neighbour, which
+is right for a hotspot. `src/services/lan-dial-policy.ts` holds the rule as a
+pure function; the native modules open the sockets they are told to.
+
+**What to publish.** The instance name is random and minted per publishing
+session, never the peer ID: an mDNS record is cleartext to the network and is
+logged by ordinary infrastructure, so a stable name would let anyone holding
+logs from two networks link them. The ring sorts on that random name, so
+discovery needs no durable identifier, and identity is proven in the ANNOUNCE
+once the link is up.
+
+This is the only transport off by default. Publishing tells every device on the
+network, and whoever runs it, that this phone is carrying Airhop, which on a
+workplace or venue network is an attendance list. The Settings copy says that
+rather than selling the speed.
+
+| Constraint       | Consequence                                                                                                                                                                                  |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Client isolation | Most guest and venue WiFi blocks peer-to-peer traffic at the access point, and it cannot be detected before trying. The UI has to say "No Airhop devices on this network" rather than spin   |
+| mDNS filtering   | Common even where ordinary traffic works. A manual join by address covers it                                                                                                                 |
+| iOS background   | A TCP socket has no equivalent of `bluetooth-central`, and a suspended app has its listener reclaimed without getting it back on resume. Foreground only, which WiFi Aware already is on iOS |
 
 ### Same-platform WiFi
 
@@ -270,7 +298,7 @@ service name, same length-prefixed frames, one TypeScript contract
 - iOS: [`WiFiAware`](https://developer.apple.com/documentation/WiFiAware) on Network framework, iOS 26 and iPhone 12 or later. Needs the `com.apple.developer.wifi-aware` entitlement, which is a managed capability rather than a switch in Xcode, and the service declared in `Info.plist` under `WiFiAwareServices`
 - Same `Transport` interface as BLE, so the mesh engine does not know which radio it has
 - No power policy of its own. `src/services/power-policy.ts` scales the BLE radios and leaves this one alone on both platforms: Aware is withdrawn by the OS under battery saver rather than dialled down by the app, and both surface that through `availabilityChanged(false)` and the controller's retry ladder. iOS additionally costs nothing while nothing is paired, since it never attaches and is never retried
-- Carries what BLE cannot: a whole attachment in one write rather than hundreds of fragments the radio can drop
+- Carries an attachment at link speed. The 467-byte fragments stay, since the receiver reassembles by index and the next hop may be Bluetooth, but the 25 ms gap between them goes: it exists because the BLE stack drops writes handed over faster than it can make them, and a socket has flow control of its own. `src/services/file-transfer-service.ts` paces on one question, whether anything on the path touches the Bluetooth radio
 
 Three things are true only on iOS, and each shapes the code:
 
@@ -905,6 +933,7 @@ So there is one module per hardware capability and no more.
 | `AirhopBLEModule`                    | Both     | BLE GATT Peripheral and Central, radio state, power mode |
 | `AirhopVoiceModule`                  | Both     | AAC-LC capture and playback for voice notes and PTT      |
 | `AirhopWiFiModule`                   | Both     | WiFi Aware same-platform fast path                       |
+| `AirhopLANModule`                    | Both     | mDNS discovery and the TCP links behind it               |
 | `AirhopWiFiPairing`                  | iOS      | The system pairing sheet that fast path needs            |
 | `AirhopTorModule`, `AirhopTorSocket` | iOS      | Embedded Arti and the SOCKS socket it fronts             |
 

--- a/ios/Airhop.xcodeproj/project.pbxproj
+++ b/ios/Airhop.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		04CD453DBC41469BB2CF2595 /* AirhopVoiceModule.mm in Resources */ = {isa = PBXBuildFile; fileRef = B5B7883FE2864809B556B722 /* AirhopVoiceModule.mm */; };
 		56B4EC76AA924F30BDF0032B /* AirhopVoiceModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E175A8511747A080C246EA /* AirhopVoiceModule.swift */; };
 		7663466FA96548F1AA63AA78 /* AirhopWiFiModule.mm in Resources */ = {isa = PBXBuildFile; fileRef = 708D4EAC142B4B5F8FF71CF5 /* AirhopWiFiModule.mm */; };
+		A1D3C4E5B6074F1288AA0101 /* AirhopLANModule.mm in Resources */ = {isa = PBXBuildFile; fileRef = A1D3C4E5B6074F1288AA0103 /* AirhopLANModule.mm */; };
+		A1D3C4E5B6074F1288AA0102 /* AirhopLANModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D3C4E5B6074F1288AA0104 /* AirhopLANModule.swift */; };
 		6A37230833884F4497E0773D /* AirhopWiFiModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A2C8F11CF745C28428706A /* AirhopWiFiModule.swift */; };
 		012A2DC7FB6347ACB2C832E6 /* AirhopWiFiPairing.mm in Resources */ = {isa = PBXBuildFile; fileRef = C105DF90A0A74D54A7BDC67F /* AirhopWiFiPairing.mm */; };
 		8BBD9D4FF4E442FE94D3D9BA /* AirhopWiFiPairing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1C4EDECF004DA490E3BF35 /* AirhopWiFiPairing.swift */; };
@@ -54,6 +56,8 @@
 		B5B7883FE2864809B556B722 /* AirhopVoiceModule.mm */ = {isa = PBXFileReference; name = "AirhopVoiceModule.mm"; path = "Airhop/AirhopVoiceModule.mm"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = sourcecode.cpp.objcpp; explicitFileType = undefined; includeInIndex = 0; };
 		66E175A8511747A080C246EA /* AirhopVoiceModule.swift */ = {isa = PBXFileReference; name = "AirhopVoiceModule.swift"; path = "Airhop/AirhopVoiceModule.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
 		708D4EAC142B4B5F8FF71CF5 /* AirhopWiFiModule.mm */ = {isa = PBXFileReference; name = "AirhopWiFiModule.mm"; path = "Airhop/AirhopWiFiModule.mm"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = sourcecode.cpp.objcpp; explicitFileType = undefined; includeInIndex = 0; };
+		A1D3C4E5B6074F1288AA0103 /* AirhopLANModule.mm */ = {isa = PBXFileReference; name = "AirhopLANModule.mm"; path = "Airhop/AirhopLANModule.mm"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = sourcecode.cpp.objcpp; explicitFileType = undefined; includeInIndex = 0; };
+		A1D3C4E5B6074F1288AA0104 /* AirhopLANModule.swift */ = {isa = PBXFileReference; name = "AirhopLANModule.swift"; path = "Airhop/AirhopLANModule.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
 		D5A2C8F11CF745C28428706A /* AirhopWiFiModule.swift */ = {isa = PBXFileReference; name = "AirhopWiFiModule.swift"; path = "Airhop/AirhopWiFiModule.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
 		C105DF90A0A74D54A7BDC67F /* AirhopWiFiPairing.mm */ = {isa = PBXFileReference; name = "AirhopWiFiPairing.mm"; path = "Airhop/AirhopWiFiPairing.mm"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = sourcecode.cpp.objcpp; explicitFileType = undefined; includeInIndex = 0; };
 		8B1C4EDECF004DA490E3BF35 /* AirhopWiFiPairing.swift */ = {isa = PBXFileReference; name = "AirhopWiFiPairing.swift"; path = "Airhop/AirhopWiFiPairing.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
@@ -119,6 +123,8 @@
 				F73C4B2BCE44B84717C4386B /* PrivacyInfo.xcprivacy */,
 				3B290BAA468A4B78973CE274 /* AirhopBLEModule.mm */,
 				76C2CC9F14BB4C94B2DF8C49 /* AirhopBLEModule.swift */,
+				A1D3C4E5B6074F1288AA0103 /* AirhopLANModule.mm */,
+				A1D3C4E5B6074F1288AA0104 /* AirhopLANModule.swift */,
 				120EE9C30B11446E9538C928 /* AirhopTorManager.swift */,
 				39F97BD127164B6FA2FA731A /* AirhopTorModule.mm */,
 				21FF1C52782B42ACAA2148D2 /* AirhopTorModule.swift */,
@@ -450,6 +456,8 @@
 				85697010AA2B5354025C23E1 /* ExpoModulesProvider.swift in Sources */,
 				EA639344B67649F692464CE6 /* AirhopBLEModule.mm in Resources */,
 				19BB318E597540DBA26683AB /* AirhopBLEModule.swift in Sources */,
+				A1D3C4E5B6074F1288AA0101 /* AirhopLANModule.mm in Resources */,
+				A1D3C4E5B6074F1288AA0102 /* AirhopLANModule.swift in Sources */,
 				6109022D312B46EA9633FD4F /* AirhopTorManager.swift in Sources */,
 				E2C2EF5ECC804D08A15A15AF /* AirhopTorModule.mm in Resources */,
 				636AA42C669E43DCA266E1F3 /* AirhopTorModule.swift in Sources */,

--- a/ios/Airhop/AirhopLANModule.mm
+++ b/ios/Airhop/AirhopLANModule.mm
@@ -1,0 +1,26 @@
+// Obj-C++ bridge: exposes AirhopLANModule (Swift) to the React Native bridge.
+// Same pattern as AirhopWiFiModule.mm, and the same method set as
+// AirhopLANModule.kt on Android, so one spec (src/bridge/NativeAirhopLAN.ts)
+// covers both platforms.
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+
+@interface RCT_EXTERN_REMAP_MODULE(AirhopLAN, AirhopLANModule, RCTEventEmitter)
+
+RCT_EXTERN_METHOD(startLAN:(NSString *)instanceName
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(stopLAN:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(connectToPeer:(NSString *)serviceName
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(writeToLANLink:(NSString *)linkID
+                  dataBase64:(NSString *)dataBase64
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+@end

--- a/ios/Airhop/AirhopLANModule.swift
+++ b/ios/Airhop/AirhopLANModule.swift
@@ -1,0 +1,620 @@
+// The LAN transport: Bonjour discovery over ordinary TCP.
+//
+// The only transport that reaches an Android phone from an iPhone over
+// something other than Bluetooth. Wi-Fi Aware cannot: Apple requires a paired
+// data path and Android has no way to complete Apple's pairing. This is plain
+// IP, so it does not care which phone anyone owns.
+//
+// Framing and the read loop are the same shapes AirhopWiFiModule uses,
+// deliberately: both carry the same length-prefixed Airhop packets and a bug
+// fixed in one should be recognisable in the other.
+//
+// Three things differ from that module, each deliberately:
+//
+//   * Classic `NWConnection` and `NWListener`, not the iOS 26 generic
+//     `NetworkConnection<TCP>`. Wi-Fi Aware needs iOS 26 regardless; this must
+//     run on the app's floor, and Bonjour over Network framework has been there
+//     since iOS 12. No availability gate anywhere below.
+//   * Discovery and dialling are split, because Bonjour returns the whole
+//     network and who to dial is a decision. TypeScript makes it
+//     (services/lan-dial-policy.ts) and this opens what it is told to.
+//   * No token tiebreak. The Wi-Fi module needs one because Apple's discovery is
+//     symmetric; here the ring already decides which side dials.
+//
+// The instance name comes from TypeScript and is never the peer ID. See
+// services/lan-controller.ts for why it rotates.
+//
+// Foreground only, structurally. iOS has no background mode for a listening
+// socket, and a suspended app has its listener reclaimed without getting it back
+// on resume. Bluetooth keeps the mesh alive with the screen off, and the Network
+// screen says so.
+
+import Foundation
+import Network
+import React
+
+enum LANConst {
+    // Must match `SERVICE_TYPE` in AirhopLANModule.kt and the `NSBonjourServices`
+    // entry in Info.plist character for character. A mismatch is two apps that
+    // cannot see each other.
+    //
+    // Not Wi-Fi Aware's `_airhop-mesh-v1._tcp`. Two services, named apart so
+    // neither reads as a typo of the other: Aware is a radio protocol needing no
+    // network, this is mDNS over an ordinary one.
+    static let serviceType = "_airhop-lan-v1._tcp"
+    static let domain = "local."
+    // 64 KiB payload plus the length prefix. Matches MAX_FRAME on the Kotlin side.
+    static let maxFrame = 65_544
+}
+
+private enum LANEvent {
+    static let peerDiscovered = "AirhopLAN.peerDiscovered"
+    static let peerLost = "AirhopLAN.peerLost"
+    static let linkConnected = "AirhopLAN.linkConnected"
+    static let linkDisconnected = "AirhopLAN.linkDisconnected"
+    static let packetReceived = "AirhopLAN.packetReceived"
+    static let availabilityChanged = "AirhopLAN.availabilityChanged"
+}
+
+// MARK: - Framing
+
+/// `[4-byte big-endian length][payload]`, byte-identical to the Kotlin module
+/// and to AirhopWiFiModule.
+///
+/// Big-endian by hand rather than reading a `UInt32`, which would come back in
+/// host order and be byte-swapped on every device this runs on.
+private enum LANFrame {
+    static func encode(_ payload: Data) -> Data {
+        let length = UInt32(payload.count)
+        var out = Data(capacity: 4 + payload.count)
+        out.append(UInt8((length >> 24) & 0xff))
+        out.append(UInt8((length >> 16) & 0xff))
+        out.append(UInt8((length >> 8) & 0xff))
+        out.append(UInt8(length & 0xff))
+        out.append(payload)
+        return out
+    }
+
+    static func decodeLength(_ header: Data) -> Int? {
+        guard header.count == 4 else { return nil }
+        let bytes = [UInt8](header)
+        let length =
+            (Int(bytes[0]) << 24) | (Int(bytes[1]) << 16) | (Int(bytes[2]) << 8) | Int(bytes[3])
+        guard length > 0, length <= LANConst.maxFrame else { return nil }
+        return length
+    }
+}
+
+// MARK: - Failures
+
+/// The rejection codes services/lan-controller.ts branches on, shared with
+/// AirhopLANModule.kt so one `classify` covers both platforms.
+private enum LANFailure: Error {
+    /// No network, or not on one that carries peers. Clears on its own.
+    case unavailable(String)
+    /// Local network access refused. On iOS the prompt is raised by browsing,
+    /// and a refusal is only reversible in Settings.
+    case permissionDenied
+    /// The listener would not start.
+    case listenFailed(String)
+    case unknownPeer(String)
+    case unknownLink(String)
+    case connectFailed(String)
+    case writeFailed(String)
+
+    var code: String {
+        switch self {
+        case .unavailable: return "LAN_UNAVAILABLE"
+        case .permissionDenied: return "PERMISSION_DENIED"
+        case .listenFailed: return "LAN_LISTEN_FAILED"
+        case .unknownPeer: return "UNKNOWN_PEER"
+        case .unknownLink: return "UNKNOWN_LINK"
+        case .connectFailed: return "CONNECT_FAILED"
+        case .writeFailed: return "WRITE_FAILED"
+        }
+    }
+
+    var message: String {
+        switch self {
+        case let .unavailable(detail): return detail
+        case .permissionDenied: return "Local network access refused"
+        case let .listenFailed(detail): return detail
+        case let .unknownPeer(name): return "No discovered peer named \(name)"
+        case let .unknownLink(id): return "No active LAN link: \(id)"
+        case let .connectFailed(detail): return detail
+        case let .writeFailed(detail): return detail
+        }
+    }
+}
+
+// MARK: - Transport
+
+/// Everything with state, confined to one serial queue.
+///
+/// Network framework delivers its callbacks on whatever queue it was given and
+/// bridge methods arrive on React Native's, so the registry and the discovery
+/// map are touched from several threads at once. One queue rather than locks:
+/// every mutation below is short, and the ordering it gives is what makes a
+/// link's connect, ready and cancel sequence readable.
+private final class LANTransport {
+    private struct Link {
+        let connection: NWConnection
+        /// The peer this link was dialled for, or nil for one we accepted. An
+        /// accepted connection is anonymous until its peer announces, and
+        /// nothing here needs the name for anything but answering "already
+        /// connected" to a repeat dial.
+        let serviceName: String?
+        var closing = false
+    }
+
+    private let emit: (String, [String: Any]) -> Void
+    private let queue = DispatchQueue(label: "org.onemindlabs.airhop.lan")
+
+    private var listener: NWListener?
+    private var browser: NWBrowser?
+    private var links: [String: Link] = [:]
+    /// Endpoints Bonjour has told us about, by the name they publish. Held
+    /// because a dial names a peer, not an address: Bonjour resolves lazily
+    /// when the connection is made, which is why nothing above needs a host.
+    private var discovered: [String: NWEndpoint] = [:]
+    /// linkID by peer name, so a repeat dial for a peer already linked resolves
+    /// without opening a second socket. TypeScript walks its dial plan on a
+    /// timer, since a link can drop while the peer's Bonjour record stays
+    /// visible, and it does not track which names are linked: that is this
+    /// module's knowledge.
+    private var linkByName: [String: String] = [:]
+    private var instanceName: String?
+    private var linkSeq = 0
+    /// Set when the browser is refused for policy, which is how a denied local
+    /// network permission arrives: there is no API to ask, and the prompt is
+    /// raised by browsing rather than by declaring the service.
+    ///
+    /// Read by the NEXT start rather than reported from here, because by the
+    /// time it lands the current start has already resolved. The controller's
+    /// retry ladder asks again within half a second, and that attempt is the one
+    /// that can say why.
+    private var policyDenied = false
+    /// The in-flight start's promise. Held because a listener is not usable at
+    /// the moment it is created: it has to reach `.ready`, and reporting success
+    /// before then would tell the controller a transport exists that cannot yet
+    /// accept a connection.
+    private var pendingStart: ((LANFailure?) -> Void)?
+    /// Reported only on transitions. A second `available: false` while already
+    /// down resets the controller's backoff, turning its retry ladder into a
+    /// tight loop.
+    private var lastReportedAvailable: Bool?
+
+    init(emit: @escaping (String, [String: Any]) -> Void) {
+        self.emit = emit
+    }
+
+    // MARK: Start and stop
+
+    func start(instanceName: String, completion: @escaping (LANFailure?) -> Void) {
+        queue.async {
+            // Idempotent: the reconciler calls start whenever it is unsure.
+            if self.listener != nil {
+                completion(nil)
+                return
+            }
+            // A refusal the previous attempt could not report in time.
+            if self.policyDenied {
+                self.policyDenied = false
+                completion(.permissionDenied)
+                return
+            }
+            self.instanceName = instanceName
+            self.lastReportedAvailable = nil
+            self.pendingStart = completion
+
+            let parameters = NWParameters.tcp
+            // Frames are small and latency matters more than packing: the mesh
+            // writes one packet per call and waits for nothing.
+            if let tcp = parameters.defaultProtocolStack.transportProtocol
+                as? NWProtocolTCP.Options
+            {
+                tcp.noDelay = true
+            }
+            // Peer-to-peer so the listener is reachable over a link-local
+            // address as well as a routed one.
+            parameters.includePeerToPeer = true
+
+            let listener: NWListener
+            do {
+                listener = try NWListener(using: parameters)
+            } catch {
+                self.instanceName = nil
+                self.pendingStart = nil
+                completion(.listenFailed(String(describing: error)))
+                return
+            }
+            listener.service = NWListener.Service(
+                name: instanceName,
+                type: LANConst.serviceType
+            )
+            listener.newConnectionHandler = { [weak self] connection in
+                self?.queue.async { self?.adopt(connection, direction: "in") }
+            }
+            listener.stateUpdateHandler = { [weak self] state in
+                guard let self else { return }
+                self.queue.async {
+                    switch state {
+                    case let .failed(error):
+                        // Most often no usable network. Whoever is still waiting
+                        // on start hears why; anyone later hears it as the
+                        // transport going away.
+                        self.settleStart(.unavailable(String(describing: error)))
+                        self.report(available: false)
+                    case .cancelled:
+                        self.report(available: false)
+                    case .ready:
+                        self.settleStart(nil)
+                        self.report(available: true)
+                    default:
+                        break
+                    }
+                }
+            }
+            self.listener = listener
+            listener.start(queue: self.queue)
+
+            self.startBrowsing(parameters: parameters)
+        }
+    }
+
+    /// Answer the in-flight start exactly once. A listener reports `.ready` and
+    /// later `.failed`, and only the first of those is the start's answer.
+    private func settleStart(_ failure: LANFailure?) {
+        guard let pending = pendingStart else { return }
+        pendingStart = nil
+        if failure != nil { instanceName = nil }
+        pending(failure)
+    }
+
+    func stop(completion: @escaping () -> Void) {
+        queue.async {
+            self.browser?.cancel()
+            self.browser = nil
+            self.listener?.cancel()
+            self.listener = nil
+            self.instanceName = nil
+            self.discovered.removeAll()
+            self.linkByName.removeAll()
+            self.settleStart(.unavailable("stopped"))
+            for id in self.links.keys { self.closeLink(id) }
+            completion()
+        }
+    }
+
+    private func report(available: Bool) {
+        guard lastReportedAvailable != available else { return }
+        lastReportedAvailable = available
+        emit(LANEvent.availabilityChanged, ["available": available])
+    }
+
+    // MARK: Discovery
+
+    private func startBrowsing(parameters: NWParameters) {
+        let descriptor = NWBrowser.Descriptor.bonjour(
+            type: LANConst.serviceType,
+            domain: LANConst.domain
+        )
+        let browser = NWBrowser(for: descriptor, using: parameters)
+        browser.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            self.queue.async {
+                if case let .failed(error) = state {
+                    // Browsing is what raises the local network prompt, so a
+                    // refusal shows up here rather than at start.
+                    if case let .dns(code) = error, code == kDNSServiceErr_PolicyDenied {
+                        self.policyDenied = true
+                    }
+                    self.report(available: false)
+                }
+            }
+        }
+        browser.browseResultsChangedHandler = { [weak self] results, _ in
+            self?.queue.async { self?.applyBrowseResults(results) }
+        }
+        self.browser = browser
+        browser.start(queue: queue)
+    }
+
+    /// Bonjour hands back the whole current set on every change rather than a
+    /// delta, so this diffs against what we hold: anything new is announced,
+    /// anything gone is retired.
+    private func applyBrowseResults(_ results: Set<NWBrowser.Result>) {
+        var seen: [String: NWEndpoint] = [:]
+        for result in results {
+            guard case let .service(name, _, _, _) = result.endpoint else { continue }
+            // Our own record comes back off the network like anyone else's.
+            if name == instanceName { continue }
+            seen[name] = result.endpoint
+        }
+
+        for (name, endpoint) in seen where discovered[name] == nil {
+            discovered[name] = endpoint
+            emit(LANEvent.peerDiscovered, ["serviceName": name])
+        }
+        for name in discovered.keys where seen[name] == nil {
+            discovered.removeValue(forKey: name)
+            emit(LANEvent.peerLost, ["serviceName": name])
+        }
+    }
+
+    // MARK: Links
+
+    func connect(to serviceName: String, completion: @escaping (LANFailure?) -> Void) {
+        queue.async {
+            guard let endpoint = self.discovered[serviceName] else {
+                completion(.unknownPeer(serviceName))
+                return
+            }
+            // Idempotent, for the reason `linkByName` exists.
+            if let existing = self.linkByName[serviceName], self.links[existing] != nil {
+                completion(nil)
+                return
+            }
+            let parameters = NWParameters.tcp
+            parameters.includePeerToPeer = true
+            let connection = NWConnection(to: endpoint, using: parameters)
+            self.adopt(
+                connection,
+                direction: "out",
+                serviceName: serviceName,
+                onReady: completion
+            )
+        }
+    }
+
+    /// Register a connection and follow it to ready or failure.
+    ///
+    /// `onReady` is the dial's promise and fires exactly once. An inbound
+    /// connection has no promise waiting, so it passes nil.
+    private func adopt(
+        _ connection: NWConnection,
+        direction: String,
+        serviceName: String? = nil,
+        onReady: ((LANFailure?) -> Void)? = nil
+    ) {
+        linkSeq += 1
+        let linkID = "lan-\(direction)-\(linkSeq)"
+        links[linkID] = Link(connection: connection, serviceName: serviceName)
+        if let serviceName { linkByName[serviceName] = linkID }
+
+        var settled = false
+        connection.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            self.queue.async {
+                switch state {
+                case .ready:
+                    if !settled {
+                        settled = true
+                        onReady?(nil)
+                    }
+                    self.emit(LANEvent.linkConnected, ["linkID": linkID])
+                    self.readFrame(linkID: linkID, connection: connection)
+                case let .failed(error):
+                    if !settled {
+                        settled = true
+                        // Most often client isolation, which every guest
+                        // network enables and which cannot be detected before
+                        // trying.
+                        onReady?(.connectFailed(String(describing: error)))
+                    }
+                    self.retire(linkID)
+                case .cancelled:
+                    if !settled {
+                        settled = true
+                        onReady?(.connectFailed("cancelled"))
+                    }
+                    self.retire(linkID)
+                default:
+                    break
+                }
+            }
+        }
+        connection.start(queue: queue)
+    }
+
+    /// One frame, then schedule the next. Recursive rather than a loop because
+    /// `receive` is callback-based: each completion queues the following read.
+    private func readFrame(linkID: String, connection: NWConnection) {
+        connection.receive(
+            minimumIncompleteLength: 4,
+            maximumLength: 4
+        ) { [weak self] header, _, isComplete, error in
+            guard let self else { return }
+            self.queue.async {
+                guard error == nil, !isComplete, let header,
+                    let length = LANFrame.decodeLength(header)
+                else {
+                    self.closeLink(linkID)
+                    return
+                }
+                connection.receive(
+                    minimumIncompleteLength: length,
+                    maximumLength: length
+                ) { payload, _, payloadComplete, payloadError in
+                    self.queue.async {
+                        guard payloadError == nil, !payloadComplete, let payload,
+                            payload.count == length
+                        else {
+                            self.closeLink(linkID)
+                            return
+                        }
+                        self.emit(
+                            LANEvent.packetReceived,
+                            [
+                                "linkID": linkID,
+                                "dataBase64": payload.base64EncodedString(),
+                            ]
+                        )
+                        self.readFrame(linkID: linkID, connection: connection)
+                    }
+                }
+            }
+        }
+    }
+
+    func write(
+        linkID: String,
+        payload: Data,
+        completion: @escaping (LANFailure?) -> Void
+    ) {
+        queue.async {
+            guard let link = self.links[linkID], !link.closing else {
+                completion(.unknownLink(linkID))
+                return
+            }
+            // `NWConnection.send` serialises on its own: frames queued from one
+            // connection go out in order and cannot interleave, which is what
+            // the Wi-Fi module needs a SerialSender to guarantee.
+            link.connection.send(
+                content: LANFrame.encode(payload),
+                completion: .contentProcessed { [weak self] error in
+                    guard let self else { return }
+                    self.queue.async {
+                        if let error {
+                            // A refused write cannot carry the rest of the
+                            // transfer either, so tear down here rather than
+                            // wait for the read loop to notice.
+                            self.closeLink(linkID)
+                            completion(.writeFailed(String(describing: error)))
+                        } else {
+                            completion(nil)
+                        }
+                    }
+                }
+            )
+        }
+    }
+
+    /// Ask a link to end. Cancelling drives the state handler, whose `.cancelled`
+    /// branch calls `retire`, which is what reports it.
+    private func closeLink(_ linkID: String) {
+        guard var link = links[linkID], !link.closing else { return }
+        link.closing = true
+        links[linkID] = link
+        link.connection.cancel()
+    }
+
+    /// Forget a link and tell TypeScript. Idempotent: a connection can report
+    /// failed and then cancelled, and only the first of those retires it.
+    private func retire(_ linkID: String) {
+        guard let link = links.removeValue(forKey: linkID) else { return }
+        // Only if it still points here: a newer link may have claimed the name,
+        // and clearing it would make the live one look absent.
+        if let name = link.serviceName, linkByName[name] == linkID {
+            linkByName.removeValue(forKey: name)
+        }
+        emit(LANEvent.linkDisconnected, ["linkID": linkID])
+    }
+}
+
+// MARK: - Bridge
+
+@objc(AirhopLANModule)
+final class AirhopLANModule: RCTEventEmitter {
+
+    private lazy var transport = LANTransport { [weak self] name, body in
+        self?.emit(name, body)
+    }
+
+    @objc override static func requiresMainQueueSetup() -> Bool { false }
+
+    override func supportedEvents() -> [String]! {
+        [
+            LANEvent.peerDiscovered,
+            LANEvent.peerLost,
+            LANEvent.linkConnected,
+            LANEvent.linkDisconnected,
+            LANEvent.packetReceived,
+            LANEvent.availabilityChanged,
+        ]
+    }
+
+    /// Callers are framework callbacks with no bridge above them, and sending
+    /// into a departed runtime traps.
+    private func emit(_ name: String, _ body: [String: Any]) {
+        guard bridge != nil else { return }
+        sendEvent(withName: name, body: body)
+    }
+
+    // MARK: Exported
+
+    @objc(startLAN:resolver:rejecter:)
+    func startLAN(
+        instanceName: String,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        transport.start(instanceName: instanceName) { failure in
+            if let failure {
+                reject(failure.code, failure.message, nil)
+            } else {
+                resolve(nil)
+            }
+        }
+    }
+
+    @objc(stopLAN:rejecter:)
+    func stopLAN(
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        transport.stop { resolve(nil) }
+    }
+
+    @objc(connectToPeer:resolver:rejecter:)
+    func connectToPeer(
+        serviceName: String,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        transport.connect(to: serviceName) { failure in
+            if let failure {
+                reject(failure.code, failure.message, nil)
+            } else {
+                resolve(nil)
+            }
+        }
+    }
+
+    @objc(writeToLANLink:dataBase64:resolver:rejecter:)
+    func writeToLANLink(
+        linkID: String,
+        dataBase64: String,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        guard let payload = Data(base64Encoded: dataBase64) else {
+            reject("INVALID_DATA", "Invalid base64 payload", nil)
+            return
+        }
+        guard payload.count <= LANConst.maxFrame - 4 else {
+            reject(
+                "FRAME_TOO_LARGE",
+                "Frame of \(payload.count) exceeds the peer's read limit",
+                nil
+            )
+            return
+        }
+        transport.write(linkID: linkID, payload: payload) { failure in
+            if let failure {
+                reject(failure.code, failure.message, nil)
+            } else {
+                resolve(nil)
+            }
+        }
+    }
+
+    // MARK: Lifecycle
+
+    /// Every link exists to hand bytes to a runtime that is gone, and a listener
+    /// nobody hears is a socket left open.
+    override func invalidate() {
+        transport.stop {}
+        super.invalidate()
+    }
+}

--- a/landing/src/i18n/content/en/faq.tsx
+++ b/landing/src/i18n/content/en/faq.tsx
@@ -187,15 +187,39 @@ export const FAQ_SECTIONS: FaqSection[] = [
         q: "Does Airhop require internet?",
         a: (
           <>
-            Not for core offline messaging, since it relies on Bluetooth. Chatting, relaying across
-            the mesh, voice notes, images, file transfers, and store-and-forward delivery all work
-            with zero internet.
+            No. Chatting, relaying across the mesh, voice notes, images, file transfers, and
+            store-and-forward delivery all work with zero internet, over Bluetooth or over a WiFi
+            network nobody has to be online for, such as a phone hotspot.
             <br />
             <br />
             For communication beyond Bluetooth range, Airhop automatically uses the{" "}
             <TextLink href="https://fiatjaf.com/nostr.html">Nostr</TextLink> internet fallback to
             reach a contact who is online but out of range. Location channels also require a
             connection.
+          </>
+        ),
+      },
+      {
+        q: "Can Airhop work over WiFi instead of Bluetooth?",
+        a: (
+          <>
+            Yes. Turn on <strong>Local network</strong> in Settings, Network, and phones on the same
+            WiFi find each other and carry the whole mesh between them, iPhone and Android alike. No
+            internet is involved, so a phone hotspot works with no service at all, and a file moves
+            in about a second instead of the minute Bluetooth takes.
+            <br />
+            <br />
+            WiFi here means the network, not the internet behind it. The router only has to let two
+            phones talk to each other, and whether it can reach the internet makes no difference.
+            That is the opposite of the internet fallback above, which uses Nostr relays to reach
+            somebody who is not nearby at all.
+            <br />
+            <br />
+            It is off by default, because announcing yourself on a network is visible to every
+            device on it and to whoever runs it. It also depends on the network: many guest, hotel
+            and airport networks block devices from talking to each other, which cannot be detected
+            in advance, so Airhop simply reports that it found nobody. Home, office and hotspot
+            networks generally work.
           </>
         ),
       },
@@ -234,7 +258,7 @@ export const FAQ_SECTIONS: FaqSection[] = [
       },
       {
         q: "What media can I send?",
-        a: "Images, voice notes, videos, and any other file format, all over Bluetooth using chunked streaming. Large files are split into fragments, paced so the radio is not overrun, and reassembled on the other side. Videos are sent as files and play inline; they are not live streams. The 1 MiB ceiling is bitchat's, enforced the moment it decodes a packet, so raising it would mean every bitchat peer silently dropping the file; photos and voice notes are capped tighter at 512 KiB for the same reason. Bluetooth carries roughly 18 KiB/s, so a file near the 1 MiB limit takes about 56 seconds, but it works with no internet at all. On Android to Android or iPhone to iPhone, a faster direct WiFi link is used automatically when both devices support it.",
+        a: "Images, voice notes, videos, and any other file format, all over Bluetooth using chunked streaming. Large files are split into fragments, paced so the radio is not overrun, and reassembled on the other side. Videos are sent as files and play inline; they are not live streams. The 1 MiB ceiling is bitchat's, enforced the moment it decodes a packet, so raising it would mean every bitchat peer silently dropping the file; photos and voice notes are capped tighter at 512 KiB for the same reason. Bluetooth carries roughly 18 KiB/s, so a file near the 1 MiB limit takes about 56 seconds, but it works with no internet at all. Over WiFi the gap between fragments is dropped, since it exists for the Bluetooth radio rather than for the protocol, and the same file moves in about a second.",
       },
       {
         q: "Why is there no video or voice calling?",

--- a/landing/src/pages/ArchitecturePage/index.tsx
+++ b/landing/src/pages/ArchitecturePage/index.tsx
@@ -699,9 +699,11 @@ export default function ArchitecturePage() {
                 what carries an iPhone to an Android over a shared network.
               </p>
               <p>
-                And WiFi currently shares the same paced send queue as Bluetooth, so it runs at
-                Bluetooth speed today. Lifting that cap is planned, and nothing in the protocol
-                stands in the way.
+                Fragments are paced apart on Bluetooth because the stack drops writes handed over
+                faster than it can make them. A socket has flow control of its own, so the gap is
+                applied only where a Bluetooth radio is actually carrying the file. The fragment
+                size itself never changes: the receiver reassembles by index, and the next hop may
+                well be Bluetooth.
               </p>
 
               <p>
@@ -714,11 +716,10 @@ export default function ArchitecturePage() {
               </p>
               <p>
                 <TextLink href="https://en.wikipedia.org/wiki/Multicast_DNS">mDNS</TextLink>{" "}
-                discovery, with ordinary TCP links behind it, covers that case. The links carry the
-                same packet frames Bluetooth carries, so nothing about the wire format moves, and
-                because it is plain IP it does not care which phone you own. That matters most where
-                Bluetooth struggles and a network already exists: a ship with steel between decks, a
-                hotel, a conference floor.
+                discovery, with ordinary TCP links behind it, closes that gap. Being plain IP, it
+                does not care which phone you own, and the links carry the same packet frames
+                Bluetooth carries. It earns its place where Bluetooth struggles but a network
+                already exists: a ship with steel between decks, a hotel, a conference floor.
               </p>
 
               <Note label="Why both WiFi paths stay">

--- a/landing/src/pages/PrivacyPage.tsx
+++ b/landing/src/pages/PrivacyPage.tsx
@@ -177,6 +177,38 @@ export default function PrivacyPage() {
           </section>
 
           <section className="border-line space-y-4 border-t pt-12 first:border-t-0 first:pt-0">
+            <h2 className="text-ink text-base font-semibold">Local network (optional)</h2>
+            <p className="text-[15px] leading-[1.75]">
+              Airhop can carry the mesh over a WiFi network you are already joined to, which is the
+              only way an iPhone and an Android phone reach each other without Bluetooth. Finding
+              other devices uses mDNS, the same mechanism a printer uses to appear on a network.
+            </p>
+            <p className="text-[15px] leading-[1.75]">
+              <strong>
+                An mDNS announcement is readable by every device on that network, and by whoever
+                runs it.
+              </strong>{" "}
+              Network equipment commonly logs it, so on a workplace, campus, hotel or venue network
+              this can tell the operator that a device there is running Airhop, with a timestamp.
+              Bluetooth reaches only as far as the radio does and is not recorded by infrastructure.
+            </p>
+            <p className="text-[15px] leading-[1.75]">
+              What the announcement contains is deliberately empty of history:{" "}
+              <strong>a random name, generated fresh each time the transport starts.</strong> It is
+              never your peer ID or any other lasting identifier, so records from two different
+              networks cannot be matched to show the same phone was on both. Your identity is proven
+              only after a connection is made, inside the same encryption every other transport
+              uses.
+            </p>
+            <p className="text-[15px] leading-[1.75]">
+              Message contents are unaffected: they stay end-to-end encrypted exactly as over
+              Bluetooth. What the network operator can observe is that connections exist, when, and
+              roughly how much data moves, in the way any network operator can. Local network is off
+              by default and stays off until you turn it on.
+            </p>
+          </section>
+
+          <section className="border-line space-y-4 border-t pt-12 first:border-t-0 first:pt-0">
             <h2 className="text-ink text-base font-semibold">Nostr and the internet (optional)</h2>
             <p className="text-[15px] leading-[1.75]">
               When Airhop uses the internet, it connects to public or user-selected Nostr relays to

--- a/src/README.md
+++ b/src/README.md
@@ -11,7 +11,7 @@ architectural layer.
 | `bridge/`        | React Native TurboModule TypeScript specifications (Codegen input only)        |
 | `core/crypto/`   | Identity, Noise XX/X, Double Ratchet, and contact exchange                     |
 | `core/encoding/` | Binary and base64 encoding helpers shared across the protocol                  |
-| `core/mesh/`     | The BLE mesh protocol, split by concern (see below)                            |
+| `core/mesh/`     | The mesh protocol, split by concern (see below)                                |
 | `core/nostr/`    | Nostr client, NIP-59 gift-wrap, geohash relay discovery, and presence          |
 | `core/payments/` | Cashu tokens, DLEQ, proof selection, NIP-61 events, and BIP-39 seed handling   |
 | `core/router/`   | Transport selection through `PeerRegistry` and `MessageRouter`                 |
@@ -33,6 +33,7 @@ than kept flat:
 | ------------ | ----------------------------------------------------------------- |
 | `wire/`      | The packet frame and every payload that rides inside it           |
 | `routing/`   | TTL flood, deduplication, fragmentation, source routes            |
+| `links/`     | Open links per transport, and the writes that go down them        |
 | `sync/`      | GCS gossip sync and outgoing request tracking                     |
 | `discovery/` | Signed announces and nickname normalization                       |
 | `rooms/`     | Private-channel and private-group crypto                          |
@@ -151,7 +152,7 @@ provided through `jest.isolateModules()`.
 The simulated environment models:
 
 - Android and iOS lifecycle behavior
-- BLE communication
+- BLE, Wi-Fi Aware, and LAN communication
 - In-memory Nostr relays implementing NIP-01
 - A Cashu mint performing real BDHKE operations
 
@@ -180,6 +181,8 @@ Current scenarios cover:
 - **Security:** replay attacks, Sybil floods, stale signed packets, recorded
   voice replay, and sender impersonation across messages, attachments, and
   announcements.
+- **Transports:** the LAN dial cap, cross-platform delivery with no Bluetooth
+  between the phones, and client isolation.
 - **Payments:** offline Cashu transfers and double-spend prevention.
 - **Recovery:** panic wipe, crash recovery, and long-running seeded soak tests.
 - **Complex network behavior:** private groups, delayed bulletin delivery,

--- a/src/__tests__/harness/bridge-shim.ts
+++ b/src/__tests__/harness/bridge-shim.ts
@@ -66,6 +66,45 @@ export const wifiBridge = {
   removeListeners: (n: number): void => currentWifi?.removeListeners(n),
 };
 
+// The LAN transport. Unlike WiFi Aware, discovery and dialling are separate:
+// mDNS finds everyone on the network and who to connect to is a decision, so
+// the module reports what it sees and opens the sockets it is told to.
+export interface LanNativeModule {
+  startLAN(instanceName: string): Promise<void>;
+  stopLAN(): Promise<void>;
+  connectToPeer(serviceName: string): Promise<void>;
+  writeToLANLink(linkID: string, dataBase64: string): Promise<void>;
+  addListener(eventName: string): void;
+  removeListeners(count: number): void;
+}
+
+let currentLan: LanNativeModule | null = null;
+
+export function installNativeLan(m: LanNativeModule | null): void {
+  currentLan = m;
+}
+
+export const lanBridge = {
+  startLAN: async (instanceName: string): Promise<void> =>
+    currentLan?.startLAN(instanceName),
+  stopLAN: async (): Promise<void> => currentLan?.stopLAN(),
+  connectToPeer: async (serviceName: string): Promise<void> =>
+    currentLan?.connectToPeer(serviceName),
+  writeToLANLink: async (linkID: string, dataBase64: string): Promise<void> =>
+    currentLan?.writeToLANLink(linkID, dataBase64),
+  addListener: (e: string): void => currentLan?.addListener(e),
+  removeListeners: (n: number): void => currentLan?.removeListeners(n),
+};
+
+export const inertLanBridge = {
+  startLAN: async (): Promise<void> => undefined,
+  stopLAN: async (): Promise<void> => undefined,
+  connectToPeer: async (): Promise<void> => undefined,
+  writeToLANLink: async (): Promise<void> => undefined,
+  addListener: (): void => undefined,
+  removeListeners: (): void => undefined,
+};
+
 // The original inert form, kept for suites that never install a module.
 export const inertWifiBridge = {
   startWiFi: async (): Promise<void> => undefined,

--- a/src/__tests__/simulation/harness/device.ts
+++ b/src/__tests__/simulation/harness/device.ts
@@ -27,10 +27,14 @@
 import type { Identity } from "@core/crypto/identity";
 import type { LinkRegistry } from "@core/mesh/links/link-registry";
 import type { AndroidBleModule, RadioPort } from "../../harness/android-native";
-import type { WifiNativeModule } from "../../harness/bridge-shim";
+import type {
+  LanNativeModule,
+  WifiNativeModule,
+} from "../../harness/bridge-shim";
 import type { IosBleModule } from "../../harness/ios-native";
 import type { AndroidPermission, DeviceOS, Platform } from "../../harness/os";
 import { eventRouter } from "./event-router";
+import type { LanPort } from "./lan-fabric";
 import type { VoiceRecord } from "./media-fabric";
 import type { RelayFabric } from "./relay-fabric";
 import type { WifiPort } from "./wifi-fabric";
@@ -93,6 +97,9 @@ export interface DeviceSpec {
   internetEnabled?: boolean;
   gatewayEnabled?: boolean;
   bridgeEnabled?: boolean;
+  // The LAN transport is off unless the user turns it on, so a scenario that
+  // wants it has to say so, the same way a person would.
+  lanEnabled?: boolean;
   liveVoiceEnabled?: boolean;
 }
 
@@ -147,6 +154,7 @@ interface Inner {
   // Captured inside the registry for the same reason everything else here is:
   // the shim holds a module-scope singleton, and each phone has its own copy.
   installWifi: (m: WifiNativeModule | null) => void;
+  installLan: (m: LanNativeModule | null) => void;
   // The event emitter this phone's native module and mesh-service share. Held
   // ONLY so the harness can prove, in a test, that two phones do not share one.
   // If they ever did, every scenario in this directory would be meaningless:
@@ -382,6 +390,36 @@ export class SimDevice {
       startWiFi: async () => undefined,
       stopWiFi: async () => undefined,
       writeToWiFiLink: async (linkID: string, dataBase64: string) => {
+        port.write(linkID, dataBase64);
+      },
+      addListener: () => undefined,
+      removeListeners: () => undefined,
+    });
+  }
+
+  // The LAN transport has one more direction than WiFi Aware: the app asks to
+  // publish under a name, and asks to dial a peer. Both are handed to the
+  // fabric, which is what knows who is on which network.
+  attachLanPort(port: LanPort): void {
+    const emitter = this.inner.emitter as {
+      emit: (event: string, body: Record<string, unknown>) => void;
+    };
+    port.emit = (event, body) => {
+      eventRouter().runAs(this.id, () => {
+        emitter.emit(event, body);
+      });
+    };
+    this.inner.installLan({
+      startLAN: async (instanceName: string) => {
+        port.start(instanceName);
+      },
+      stopLAN: async () => {
+        port.stop();
+      },
+      connectToPeer: async (serviceName: string) => {
+        port.connect(serviceName);
+      },
+      writeToLANLink: async (linkID: string, dataBase64: string) => {
         port.write(linkID, dataBase64);
       },
       addListener: () => undefined,
@@ -1514,6 +1552,13 @@ function buildSandbox(
         }
       ).installNativeWifi(m);
     };
+    const installLan = (m: LanNativeModule | null): void => {
+      (
+        shim as unknown as {
+          installNativeLan: (x: LanNativeModule | null) => void;
+        }
+      ).installNativeLan(m);
+    };
 
     const stores: Record<string, StoreLike> = {
       chatStore: require(P.chatStore).useChatStore,
@@ -1542,6 +1587,11 @@ function buildSandbox(
       stores.settingsStore,
       "setGatewayEnabled",
       spec.gatewayEnabled ?? false,
+    );
+    call(
+      stores.settingsStore,
+      "setLanTransportEnabled",
+      spec.lanEnabled ?? false,
     );
     call(stores.settingsStore, "setBridgeEnabled", spec.bridgeEnabled ?? false);
     call(
@@ -1640,6 +1690,7 @@ function buildSandbox(
       wallet,
       pay,
       installWifi,
+      installLan,
       selectAccounts,
       emitter,
     };

--- a/src/__tests__/simulation/harness/lan-fabric.ts
+++ b/src/__tests__/simulation/harness/lan-fabric.ts
@@ -1,0 +1,280 @@
+// The LAN transport, as a fabric.
+//
+// A network, not a set of pairs. That is what separates it from WifiFabric:
+// mDNS reveals EVERY device at once, the shape Bluetooth cannot produce and the
+// one `lan-dial-policy.ts` exists to survive. A fabric that revealed peers pair
+// by pair would never exercise it.
+//
+// Three rules it models, all real and all easy to get wrong:
+//
+//   1. Discovery is a network. Joining reveals you to everyone already there,
+//      and them to you, in one go.
+//   2. Linking is a decision. The fabric never opens a link on its own: a
+//      device dials, having been told who to. A wrong cap shows up here as a
+//      wrong socket count.
+//   3. Client isolation exists. Most venue WiFi passes mDNS and drops the TCP,
+//      and nothing in the app can detect it before trying.
+//
+// Deliberately NOT modelled: MTU, loss, per-hop latency. A LAN link is a TCP
+// socket, up or not, carrying whole frames. Same reasoning WifiFabric records.
+
+import type { World } from "./world";
+
+// What the fabric needs from a device. Structural, so a SimDevice satisfies it
+// without the fabric importing one.
+export interface LanNode {
+  readonly id: string;
+  attachLanPort(port: LanPort): void;
+}
+
+export interface LanPort {
+  // The app published under this name. Chosen by the app, random per session,
+  // and never the peer ID.
+  start(instanceName: string): void;
+  stop(): void;
+  // The app asked to open a link to a peer it was told about.
+  connect(serviceName: string): void;
+  write(linkID: string, dataBase64: string): void;
+  // Raise one of the `AirhopLAN.*` events on this device.
+  emit(event: string, body: Record<string, unknown>): void;
+}
+
+// A link is named by the far side, matching how mesh-service treats a linkID as
+// an opaque handle it writes back to.
+function handleFor(farSideID: string): string {
+  return `lan:${farSideID}`;
+}
+
+function pairKey(a: string, b: string): string {
+  return a < b ? `${a}|${b}` : `${b}|${a}`;
+}
+
+function base64ByteLength(b64: string): number {
+  const padding = b64.endsWith("==") ? 2 : b64.endsWith("=") ? 1 : 0;
+  return Math.max(0, (b64.length * 3) / 4 - padding);
+}
+
+interface Publisher {
+  readonly deviceID: string;
+  readonly instanceName: string;
+  readonly network: string;
+}
+
+export class LanFabric {
+  private readonly nodes = new Map<string, LanNode>();
+  private readonly ports = new Map<string, LanPort>();
+  // Which network each device is joined to, if any.
+  private readonly joined = new Map<string, string>();
+  // Devices currently publishing, by the name they publish under.
+  private readonly publishers = new Map<string, Publisher>();
+  // Networks whose access point refuses peer-to-peer traffic.
+  private readonly isolated = new Set<string>();
+  // Undirected pairs currently linked, keyed a|b with a < b.
+  private readonly links = new Set<string>();
+  private disposed = false;
+
+  // Counters a scenario can assert on. `dialsRefused` is the client-isolation
+  // one: peers were found and none of them could be reached.
+  framesCarried = 0;
+  bytesCarried = 0;
+  dialsAttempted = 0;
+  dialsRefused = 0;
+
+  constructor(private readonly world: World) {
+    world.onClose(() => {
+      this.disposed = true;
+    });
+  }
+
+  add(node: LanNode): void {
+    this.nodes.set(node.id, node);
+    const port: LanPort = {
+      start: (instanceName) => this.onStart(node.id, instanceName),
+      stop: () => this.onStop(node.id),
+      connect: (serviceName) => this.onConnect(node.id, serviceName),
+      write: (linkID, dataBase64) => this.onWrite(node.id, linkID, dataBase64),
+      // Replaced by the device when it attaches; this default keeps the type
+      // honest for a node that never wires an emitter.
+      emit: () => undefined,
+    };
+    node.attachLanPort(port);
+    this.ports.set(node.id, port);
+  }
+
+  // Put a device on a network. Joining is not publishing: the app still has to
+  // be running with the transport switched on before anything is announced.
+  join(deviceID: string, network: string): void {
+    this.joined.set(deviceID, network);
+    this.world.say("LAN_JOINED", `${deviceID} joined ${network}`);
+    // Already publishing on another network, or none: re-announce so the new
+    // network sees it and the old one does not.
+    const existing = this.publishers.get(this.nameOf(deviceID) ?? "");
+    if (existing !== undefined) this.onStart(deviceID, existing.instanceName);
+  }
+
+  // Take a device off the network, as walking out of the building does.
+  leave(deviceID: string): void {
+    this.joined.delete(deviceID);
+    this.onStop(deviceID);
+    for (const key of [...this.links]) {
+      const [a, b] = key.split("|");
+      if (a === deviceID || b === deviceID) this.unlink(a, b);
+    }
+    this.world.say("LAN_LEFT", `${deviceID} left the network`);
+  }
+
+  // Make a network behave the way most guest WiFi does: mDNS crosses, TCP does
+  // not. Cannot be detected before dialling, which is the point.
+  setClientIsolation(network: string, isolated: boolean): void {
+    if (isolated) this.isolated.add(network);
+    else this.isolated.delete(network);
+    this.world.say(
+      "LAN_ISOLATION",
+      `${network} peer-to-peer traffic ${isolated ? "blocked" : "allowed"}`,
+    );
+  }
+
+  linkCount(): number {
+    return this.links.size;
+  }
+
+  linkCountFor(deviceID: string): number {
+    let count = 0;
+    for (const key of this.links) {
+      const [a, b] = key.split("|");
+      if (a === deviceID || b === deviceID) count++;
+    }
+    return count;
+  }
+
+  isLinked(aID: string, bID: string): boolean {
+    return this.links.has(pairKey(aID, bID));
+  }
+
+  private nameOf(deviceID: string): string | undefined {
+    for (const p of this.publishers.values()) {
+      if (p.deviceID === deviceID) return p.instanceName;
+    }
+    return undefined;
+  }
+
+  // The app started publishing. Everyone already on this network learns about
+  // it, and it learns about them, in the one burst mDNS delivers.
+  private onStart(deviceID: string, instanceName: string): void {
+    if (this.disposed) return;
+    const network = this.joined.get(deviceID);
+    if (network === undefined) {
+      // Publishing while on no network reaches nobody, which is exactly what
+      // the real module reports as unavailable.
+      this.world.say("LAN_NO_NETWORK", `${deviceID} published with no network`);
+      return;
+    }
+    const previous = this.nameOf(deviceID);
+    if (previous !== undefined) this.publishers.delete(previous);
+    this.publishers.set(instanceName, { deviceID, instanceName, network });
+    this.world.say("LAN_PUBLISHED", `${deviceID} as ${instanceName}`);
+
+    for (const peer of this.publishers.values()) {
+      if (peer.deviceID === deviceID || peer.network !== network) continue;
+      this.reveal(deviceID, peer);
+      this.reveal(peer.deviceID, {
+        deviceID,
+        instanceName,
+        network,
+      });
+    }
+  }
+
+  private onStop(deviceID: string): void {
+    const name = this.nameOf(deviceID);
+    if (name === undefined) return;
+    this.publishers.delete(name);
+    for (const peer of this.publishers.values()) {
+      this.ports.get(peer.deviceID)?.emit("AirhopLAN.peerLost", {
+        serviceName: name,
+      });
+    }
+    this.world.say("LAN_UNPUBLISHED", `${deviceID} stopped publishing`);
+  }
+
+  private reveal(toDeviceID: string, peer: Publisher): void {
+    this.ports.get(toDeviceID)?.emit("AirhopLAN.peerDiscovered", {
+      serviceName: peer.instanceName,
+    });
+  }
+
+  // A device dialled a peer it was told about. This is the only way a link
+  // comes up: the fabric never decides.
+  private onConnect(fromID: string, serviceName: string): void {
+    if (this.disposed) return;
+    this.dialsAttempted++;
+    const peer = this.publishers.get(serviceName);
+    const network = this.joined.get(fromID);
+    if (peer === undefined || network === undefined) {
+      this.dialsRefused++;
+      return;
+    }
+    if (peer.network !== network) {
+      this.dialsRefused++;
+      return;
+    }
+    if (this.isolated.has(network)) {
+      // The access point drops it. Discovery worked and the connection does
+      // not, which is exactly what a venue network does and what the app can
+      // only find out by trying.
+      this.dialsRefused++;
+      this.world.say(
+        "LAN_ISOLATED_DIAL",
+        `${fromID} could not reach ${peer.deviceID}: client isolation`,
+      );
+      return;
+    }
+    this.linkUp(fromID, peer.deviceID);
+  }
+
+  private linkUp(aID: string, bID: string): void {
+    const key = pairKey(aID, bID);
+    if (this.links.has(key)) return;
+    this.links.add(key);
+    this.world.say("LAN_LINK_UP", `${aID} <-> ${bID}`);
+    this.ports.get(aID)?.emit("AirhopLAN.linkConnected", {
+      linkID: handleFor(bID),
+    });
+    this.ports.get(bID)?.emit("AirhopLAN.linkConnected", {
+      linkID: handleFor(aID),
+    });
+  }
+
+  unlink(aID: string, bID: string): void {
+    const key = pairKey(aID, bID);
+    if (!this.links.delete(key)) return;
+    this.world.say("LAN_LINK_DOWN", `${aID} <-> ${bID}`);
+    this.ports.get(aID)?.emit("AirhopLAN.linkDisconnected", {
+      linkID: handleFor(bID),
+    });
+    this.ports.get(bID)?.emit("AirhopLAN.linkDisconnected", {
+      linkID: handleFor(aID),
+    });
+  }
+
+  private onWrite(fromID: string, linkID: string, dataBase64: string): void {
+    if (this.disposed) return;
+    const toID = linkID.startsWith("lan:") ? linkID.slice("lan:".length) : "";
+    if (!this.links.has(pairKey(fromID, toID))) return;
+    const to = this.ports.get(toID);
+    if (to === undefined) return;
+
+    this.framesCarried++;
+    this.bytesCarried += base64ByteLength(dataBase64);
+
+    // A whole frame in one piece, on a later tick so nothing in the app can
+    // depend on a synchronous write.
+    setTimeout(() => {
+      if (this.disposed) return;
+      to.emit("AirhopLAN.packetReceived", {
+        linkID: handleFor(fromID),
+        dataBase64,
+      });
+    }, 1);
+  }
+}

--- a/src/__tests__/simulation/scenarios/lan.test.ts
+++ b/src/__tests__/simulation/scenarios/lan.test.ts
@@ -1,0 +1,362 @@
+/**
+ * @jest-environment node
+ */
+// The LAN transport, end to end through the real mesh engine.
+//
+// What makes this worth simulating rather than unit testing: mDNS reveals every
+// device on a network at once, which is a shape Bluetooth cannot produce and
+// therefore a shape nothing else in this suite exercises. The cap that keeps it
+// survivable is a pure function with its own tests; these scenarios check that
+// the cap is actually reached through the controller, the registry, the router
+// and the radios, with no help.
+//
+// The properties that matter:
+//
+//   * Nothing is published until the user asks. This is the only transport
+//     where consent is a precondition, because an mDNS record tells everyone on
+//     the network, and whoever runs it, that this phone is carrying Airhop.
+//   * A message crosses between an iPhone and an Android phone. Neither
+//     Bluetooth range nor WiFi Aware is available here, so if it arrives, it
+//     arrived over LAN. This is the gap the transport exists to fill.
+//   * A crowded network does not become a full mesh. Thirty phones each hold
+//     eight links, not twenty-nine.
+//   * Client isolation looks like an empty network and not like a bug. Most
+//     venue WiFi lets mDNS through and drops the TCP, and the app cannot tell
+//     before trying.
+
+jest.mock("expo-location", () => ({}));
+jest.mock("react-native/Libraries/EventEmitter/RCTDeviceEventEmitter", () =>
+  (
+    require("../harness/event-router") as { routerModule: () => unknown }
+  ).routerModule(),
+);
+jest.mock("@bridge/NativeAirhopBLE", () => {
+  const shim = require("../../harness/bridge-shim");
+  return { __esModule: true, default: shim.bleBridge };
+});
+jest.mock("@bridge/NativeAirhopLAN", () => {
+  const shim = require("../../harness/bridge-shim");
+  return { __esModule: true, default: shim.lanBridge };
+});
+
+import { SimDevice, type DeviceSpec } from "../harness/device";
+import { noCrashes } from "../harness/invariants";
+import { LanFabric } from "../harness/lan-fabric";
+import { RadioFabric } from "../harness/radio-fabric";
+import { Scenario, waitFor } from "../harness/scenario";
+
+jest.setTimeout(120_000);
+
+let scenario: Scenario | null = null;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  scenario?.close();
+  scenario = null;
+  jest.useRealTimers();
+});
+
+function phone(
+  id: string,
+  seedByte: number,
+  platform: "android" | "ios" = "android",
+  lanEnabled = true,
+): DeviceSpec {
+  return { id, platform, seedByte, lanEnabled };
+}
+
+// Every phone in the room, on one network, with no Bluetooth between any of
+// them. Anything that arrives, arrived over LAN.
+function room(
+  s: Scenario,
+  specs: readonly DeviceSpec[],
+): { radio: RadioFabric; lan: LanFabric; devices: SimDevice[] } {
+  const radio = new RadioFabric(s.world);
+  const lan = new LanFabric(s.world);
+  const devices = specs.map((spec) => SimDevice.create(s.world, spec));
+  for (const d of devices) {
+    radio.add(d);
+    lan.add(d);
+  }
+  radio.setTopology([]);
+  return { radio, lan, devices };
+}
+
+test("L01 nothing is published until the user turns the transport on", async () => {
+  const s = (scenario = new Scenario({
+    id: "L01",
+    title: "consent is a precondition, not a preference",
+    seed: 700,
+  }));
+  const { lan, devices } = room(s, [
+    phone("a", 11, "android", false),
+    phone("b", 22, "android", false),
+  ]);
+  const [a, b] = devices;
+  s.track(a, b);
+  lan.join("a", "office");
+  lan.join("b", "office");
+  a.launch();
+  b.launch();
+
+  await s.world.advance(20_000);
+
+  s.check(
+    "neither phone dialled anything",
+    lan.dialsAttempted === 0,
+    `dials=${lan.dialsAttempted}`,
+  );
+  s.check("no LAN link exists", lan.linkCount() === 0);
+  s.check(
+    "and they never found each other",
+    !a.peers().includes(b.peerID),
+    `a sees ${a.peers().length} peers`,
+  );
+
+  s.expectNone("process health", noCrashes(devices));
+  s.assert(true);
+});
+
+test("L02 an iPhone and an Android phone meet over the network", async () => {
+  const s = (scenario = new Scenario({
+    id: "L02",
+    title: "the gap WiFi Aware cannot fill",
+    seed: 701,
+  }));
+  const { lan, devices } = room(s, [
+    phone("a", 11, "android"),
+    phone("b", 22, "ios"),
+  ]);
+  const [a, b] = devices;
+  s.track(a, b);
+  lan.join("a", "hotspot");
+  lan.join("b", "hotspot");
+  a.launch();
+  b.launch();
+
+  s.check(
+    "no Bluetooth link exists between them",
+    a.bleLinkCount() === 0 && b.bleLinkCount() === 0,
+  );
+
+  const met = await waitFor(
+    s.world,
+    () => a.peers().includes(b.peerID) && b.peers().includes(a.peerID),
+    40_000,
+  );
+  s.check(
+    "they discovered each other across platforms",
+    met,
+    `a=[${a.peers().join(",")}] b=[${b.peers().join(",")}]`,
+  );
+
+  const channel = "#bluetooth";
+  a.joinChannel(channel);
+  b.joinChannel(channel);
+  a.send(channel, "the bridge is out");
+
+  const heard = await waitFor(
+    s.world,
+    () => b.texts(channel).includes("the bridge is out"),
+    30_000,
+  );
+  s.check(
+    "and the message crossed",
+    heard,
+    `b=[${b.texts(channel).join("|")}]`,
+  );
+  // The proof it went over LAN and not some path the harness left open: the
+  // fabric counted the bytes itself.
+  s.check(
+    "over the LAN fabric, which carried every byte",
+    lan.framesCarried > 0 && lan.linkCount() === 1,
+    `frames=${lan.framesCarried} links=${lan.linkCount()}`,
+  );
+
+  s.expectNone("process health", noCrashes(devices));
+  s.assert(true);
+});
+
+test("L03 a crowded network does not become a full mesh", async () => {
+  const s = (scenario = new Scenario({
+    id: "L03",
+    title: "the cap holds through the whole stack",
+    seed: 702,
+  }));
+  // Twelve phones is past the eight-link cap while staying inside the time a
+  // scenario should take. Uncapped this is 66 links; capped it is 48.
+  const specs = Array.from({ length: 12 }, (_, i) =>
+    phone(`p${String(i)}`, 10 + i),
+  );
+  const { lan, devices } = room(s, specs);
+  s.track(...devices);
+  for (const spec of specs) lan.join(spec.id, "conference");
+  for (const d of devices) d.launch();
+
+  await s.world.advance(30_000);
+
+  const counts = devices.map((d) => lan.linkCountFor(d.id));
+  const worst = Math.max(...counts);
+  s.check(
+    "no phone holds more than the cap",
+    worst <= 8,
+    `most links on one phone = ${worst} (all: ${counts.join(",")})`,
+  );
+  s.check(
+    "and it is not a full mesh",
+    lan.linkCount() < (specs.length * (specs.length - 1)) / 2,
+    `links=${lan.linkCount()} of a possible ${(specs.length * (specs.length - 1)) / 2}`,
+  );
+  // Exactly the cap, not merely under it: the ring gives every phone eight
+  // neighbours at this size, so a cap that silently collapsed to one or two
+  // would still pass a "no more than eight" check.
+  s.check(
+    "every phone holds exactly the cap",
+    counts.every((c) => c === 8),
+    `counts=${counts.join(",")}`,
+  );
+  s.check(
+    "which is the ring's total, counted once per pair",
+    lan.linkCount() === (specs.length * 8) / 2,
+    `links=${lan.linkCount()} expected ${(specs.length * 8) / 2}`,
+  );
+
+  s.expectNone("process health", noCrashes(devices));
+  s.assert(true);
+});
+
+test("L03b a message relays across the LAN ring with no Bluetooth anywhere", async () => {
+  const s = (scenario = new Scenario({
+    id: "L03b",
+    title: "multi-hop over LAN alone",
+    seed: 705,
+  }));
+  // Twelve phones is past the eight-link cap, so the ring is not a full mesh
+  // and at least one pair is two hops apart. With no Bluetooth between anyone,
+  // anything that arrives was relayed by a LAN peer.
+  const specs = Array.from({ length: 12 }, (_, i) =>
+    phone(`p${String(i)}`, 40 + i),
+  );
+  const { lan, devices } = room(s, specs);
+  s.track(...devices);
+  for (const spec of specs) lan.join(spec.id, "conference");
+  for (const d of devices) d.launch();
+  await s.world.advance(30_000);
+
+  const channel = "#bluetooth";
+  for (const d of devices) d.joinChannel(channel);
+
+  // The ring wraps, so the first and last phones are neighbours. Pick a peer
+  // the ring genuinely leaves two hops away rather than assuming one.
+  const [first] = devices;
+  const last = devices.find(
+    (d) => d !== first && !lan.isLinked(first.id, d.id),
+  );
+  s.check(
+    "the ring leaves someone more than one hop away",
+    last !== undefined,
+    `${first.id} is linked to ${String(lan.linkCountFor(first.id))} of ${String(devices.length - 1)}`,
+  );
+  if (last === undefined) {
+    s.assert(true);
+    return;
+  }
+
+  first.send(channel, "relayed across the ring");
+  const heard = await waitFor(
+    s.world,
+    () => last.texts(channel).includes("relayed across the ring"),
+    40_000,
+  );
+  s.check(
+    "and the far end heard it anyway",
+    heard,
+    `${last.id} = [${last.texts(channel).join("|")}]`,
+  );
+  s.check(
+    "with no Bluetooth link anywhere in the room",
+    devices.every((d) => d.bleLinkCount() === 0),
+  );
+
+  s.expectNone("process health", noCrashes(devices));
+  s.assert(true);
+});
+
+test("L04 client isolation looks like an empty network, not a broken app", async () => {
+  const s = (scenario = new Scenario({
+    id: "L04",
+    title: "discovery crosses, the connection does not",
+    seed: 703,
+  }));
+  const { lan, devices } = room(s, [
+    phone("a", 11, "android"),
+    phone("b", 22, "android"),
+  ]);
+  const [a, b] = devices;
+  s.track(a, b);
+  lan.setClientIsolation("guest", true);
+  lan.join("a", "guest");
+  lan.join("b", "guest");
+  a.launch();
+  b.launch();
+
+  await s.world.advance(30_000);
+
+  s.check(
+    "both phones tried to connect",
+    lan.dialsAttempted > 0,
+    `dials=${lan.dialsAttempted}`,
+  );
+  s.check(
+    "every attempt was dropped by the access point",
+    lan.dialsRefused === lan.dialsAttempted && lan.linkCount() === 0,
+    `refused=${lan.dialsRefused} of ${lan.dialsAttempted}, links=${lan.linkCount()}`,
+  );
+  s.check(
+    "so neither phone believes it has a peer",
+    !a.peers().includes(b.peerID) && !b.peers().includes(a.peerID),
+  );
+
+  s.expectNone("process health", noCrashes(devices));
+  s.assert(true);
+});
+
+test("L05 leaving the network takes the links with it", async () => {
+  const s = (scenario = new Scenario({
+    id: "L05",
+    title: "a phone that walks out does not linger as reachable",
+    seed: 704,
+  }));
+  const { lan, devices } = room(s, [
+    phone("a", 11, "android"),
+    phone("b", 22, "android"),
+  ]);
+  const [a, b] = devices;
+  s.track(a, b);
+  lan.join("a", "cafe");
+  lan.join("b", "cafe");
+  a.launch();
+  b.launch();
+
+  const met = await waitFor(
+    s.world,
+    () => a.peers().includes(b.peerID),
+    40_000,
+  );
+  s.check("they met first", met);
+
+  lan.leave("b");
+  await s.world.advance(5_000);
+
+  s.check(
+    "the link is gone on both sides",
+    lan.linkCount() === 0,
+    `links=${lan.linkCount()}`,
+  );
+
+  s.expectNone("process health", noCrashes(devices));
+  s.assert(true);
+});

--- a/src/bridge/NativeAirhopLAN.ts
+++ b/src/bridge/NativeAirhopLAN.ts
@@ -1,0 +1,87 @@
+// The native contract for the LAN transport: mDNS discovery over ordinary TCP.
+//
+// Hand-maintained, not Codegen input. See NativeAirhopBLE.ts for why.
+//
+// Backed by AirhopLANModule.kt (NsdManager) and AirhopLANModule.swift
+// (NWListener / NWBrowser on Network framework). One contract, two
+// implementations, and the mesh engine does not know which it has.
+//
+// This is the only transport that reaches an iPhone and an Android phone over
+// something other than Bluetooth. WiFi Aware cannot: Apple demands a paired
+// data path Android cannot complete. Being plain IP, this does not care which
+// phone anyone owns.
+//
+// Discovery and dialling are split, unlike AirhopWiFi where native connects to
+// whatever it finds. mDNS finds EVERYONE on the network, and connecting to
+// everyone is a full mesh whose cost grows with the square of the room. Who to
+// dial is therefore a decision, and decisions live in TypeScript: native
+// reports what it sees and opens the sockets it is told to. See
+// services/lan-controller.ts for the rule.
+//
+// Callers optional-chain, and lan-controller.ts reads a missing module as
+// permanently unsupported.
+//
+// Events emitted by native code:
+//
+//   AirhopLAN.peerDiscovered      { serviceName }
+//   AirhopLAN.peerLost            { serviceName }
+//   AirhopLAN.linkConnected       { linkID }
+//   AirhopLAN.linkDisconnected    { linkID }
+//   AirhopLAN.packetReceived      { linkID, dataBase64 }
+//   AirhopLAN.availabilityChanged { available }
+//
+// `availabilityChanged` tells the reconciler to forget it is started, the same
+// contract AirhopWiFi has. Android carries both edges off the network callback;
+// iOS reports the falling edge only, so the controller answers a drop with its
+// retry ladder rather than waiting to be told the network came back.
+import type { TurboModule } from "react-native";
+import { TurboModuleRegistry } from "react-native";
+
+export interface Spec extends TurboModule {
+  // Publish a service instance, start browsing for others, and open a listening
+  // socket. Rejects with a `code` the caller branches on, since they separate
+  // retrying from giving up:
+  //
+  //   LAN_UNSUPPORTED     no mDNS stack, or an OS below the floor. Permanent.
+  //   LAN_UNAVAILABLE     no network, or not on WiFi. Clears on its own.
+  //   PERMISSION_DENIED   local network access refused. Android asks at
+  //                       runtime; on iOS the prompt is raised by browsing, and
+  //                       a refusal is only reversible in Settings.
+  //   LAN_LISTEN_FAILED   anything else.
+  //
+  // `instanceName` is chosen by TypeScript and MUST NOT be the peer ID. See
+  // services/lan-controller.ts for what an mDNS record exposes and why the name
+  // rotates; identity is proven in the ANNOUNCE once the link is up.
+  startLAN(instanceName: string): Promise<void>;
+
+  // Stop publishing and browsing, close every link, release the listener.
+  stopLAN(): Promise<void>;
+
+  // Open a link to a peer reported by `peerDiscovered`.
+  //
+  // Named by its service name, which is all the app knows and all it should:
+  // Bonjour on iOS resolves lazily at connect time, and Android keeps the
+  // address it resolved. Resolves once the socket is up; `linkConnected`
+  // follows with the link ID.
+  //
+  // Idempotent: a peer already linked resolves without opening a second socket.
+  // The controller walks its dial plan on a timer, since a link can drop while
+  // the peer's record stays visible. Which names are linked stays down here.
+  //
+  // Rejects with UNKNOWN_PEER or CONNECT_FAILED. Nothing branches on which:
+  // both mean no link, and the next pass asks again.
+  connectToPeer(serviceName: string): Promise<void>;
+
+  // Base64 bytes to an active link; native frames them with a 4-byte big-endian
+  // length prefix, byte-identical to AirhopWiFi. Rejects with UNKNOWN_LINK,
+  // INVALID_DATA, FRAME_TOO_LARGE, WRITE_FAILED or LINK_CLOSED.
+  writeToLANLink(linkID: string, dataBase64: string): Promise<void>;
+
+  // Required by the NativeEventEmitter contract.
+  addListener(eventName: string): void;
+  removeListeners(count: number): void;
+}
+
+// `get`, not `getEnforcing`: a build without the module must still run the
+// mesh, and a missing module is an answer rather than a crash.
+export default TurboModuleRegistry.get<Spec>("AirhopLAN");

--- a/src/core/mesh/links/__tests__/link-registry.test.ts
+++ b/src/core/mesh/links/__tests__/link-registry.test.ts
@@ -266,12 +266,58 @@ describe("LinkRegistry", () => {
       expect(links.directPeers()).toEqual(["peer-a", "peer-b"]);
     });
 
+    it("directPeers() with a kind lists only peers reachable on it", () => {
+      links.open("ble", "c:1");
+      links.open("wifi", "wifi-1");
+      links.bind("c:1", "peer-a");
+      links.bind("wifi-1", "peer-b");
+
+      expect(links.directPeers("ble")).toEqual(["peer-a"]);
+      expect(links.directPeers("wifi")).toEqual(["peer-b"]);
+      expect(links.directPeers()).toEqual(["peer-a", "peer-b"]);
+    });
+
     it("omits links nobody has announced on from direct peers", () => {
       links.open("ble", "c:1");
       links.open("ble", "c:2");
       links.bind("c:2", "peer-b");
 
       expect(links.directPeers()).toEqual(["peer-b"]);
+    });
+  });
+
+  // Matches bitchat's `peerRegistry.connectedCount`: how crowded the Bluetooth
+  // room is, which is what relay jitter and the time-critical TTL cap scale by.
+  describe("degree", () => {
+    it("counts a dual-role peer once, not once per link", () => {
+      links.open("ble", "c:1");
+      links.open("ble", "p:1");
+      links.bind("c:1", "peer-a");
+      links.bind("p:1", "peer-a");
+
+      expect(links.size("ble")).toBe(2);
+      expect(links.degree()).toBe(1);
+    });
+
+    it("ignores transports that do not share the Bluetooth radio", () => {
+      links.open("ble", "c:1");
+      links.open("wifi", "wifi-1");
+      links.bind("c:1", "peer-a");
+      links.bind("wifi-1", "peer-b");
+
+      expect(links.size()).toBe(2);
+      expect(links.degree()).toBe(1);
+    });
+
+    it("ignores a link nobody has announced on yet", () => {
+      links.open("ble", "c:1");
+
+      expect(links.size("ble")).toBe(1);
+      expect(links.degree()).toBe(0);
+    });
+
+    it("is zero with no links at all", () => {
+      expect(links.degree()).toBe(0);
     });
   });
 

--- a/src/core/mesh/links/__tests__/link-registry.test.ts
+++ b/src/core/mesh/links/__tests__/link-registry.test.ts
@@ -29,7 +29,7 @@ function recorder(): Recorder {
   };
   return {
     writes,
-    writers: { ble: write(), wifi: write() },
+    writers: { ble: write(), wifi: write(), lan: write() },
     fail: (linkID) => failing.add(linkID),
   };
 }
@@ -251,7 +251,7 @@ describe("LinkRegistry", () => {
       links.open("wifi", "wifi-2");
       links.open("ble", "c:2");
 
-      expect(TRANSPORT_KINDS).toEqual(["ble", "wifi"]);
+      expect(TRANSPORT_KINDS).toEqual(["ble", "wifi", "lan"]);
       expect(links.linkIDs()).toEqual(["c:1", "c:2", "wifi-1", "wifi-2"]);
     });
 

--- a/src/core/mesh/links/link-registry.ts
+++ b/src/core/mesh/links/link-registry.ts
@@ -21,14 +21,23 @@
 // The order every observable list is enumerated in. Distinct from
 // `SEND_PREFERENCE`: this is "what order do we list things in", that is "which
 // link do we use".
-export const TRANSPORT_KINDS = ["ble", "wifi"] as const;
+//
+// Bluetooth first, and LAN last, because the announce carries only the first
+// ten `directPeers()` as its neighbour list (TLV 0x04) and that list is the
+// mesh graph other clients draw. A phone on a busy network holds more LAN peers
+// than Bluetooth ones, and letting them crowd out the Bluetooth neighbours
+// would hand bitchat a graph full of edges it cannot use.
+export const TRANSPORT_KINDS = ["ble", "wifi", "lan"] as const;
 
 export type TransportKind = (typeof TRANSPORT_KINDS)[number];
 
-// Which link to take when a peer is reachable on more than one transport. WiFi
-// first: it exists to move an attachment BLE would split into hundreds of paced
-// writes, so whenever both are held the fast one is the point of having it.
-const SEND_PREFERENCE: readonly TransportKind[] = ["wifi", "ble"];
+// Which link to take when a peer is reachable on more than one transport,
+// fastest first.
+//
+// WiFi Aware leads: it is a direct radio link with no access point in the path.
+// LAN goes phone to router to phone, still far past Bluetooth's ~18 KiB/s.
+// Bluetooth is the floor and the fallback.
+const SEND_PREFERENCE: readonly TransportKind[] = ["wifi", "lan", "ble"];
 
 export interface Link {
   readonly id: string;
@@ -55,8 +64,8 @@ export class LinkRegistry {
   //
   // One table rather than one per transport because the native modules namespace
   // link IDs and they cannot collide: BLE issues `c:<id>` and `p:<id>` on both
-  // platforms, WiFi issues `wifi-<n>` on iOS and `wifi-in-<n>` / `wifi-out-<n>`
-  // on Android.
+  // platforms, WiFi issues `wifi-<n>` / `wifi-in-<n>` / `wifi-out-<n>`, and LAN
+  // issues `lan-in-<n>` / `lan-out-<n>`.
   private readonly kindByLink = new Map<string, TransportKind>();
 
   // linkID to the peer bound to it. Not every open link has one: a link is a

--- a/src/core/mesh/links/link-registry.ts
+++ b/src/core/mesh/links/link-registry.ts
@@ -211,14 +211,17 @@ export class LinkRegistry {
     return ids;
   }
 
-  // Peers we hold a link to, deduplicated, since a peer on two transports is
-  // still one peer. Order matters to both callers: a sync request is link-local, so
-  // asking a peer three hops away wastes a write, and couriers are the first few
-  // of these.
-  directPeers(): readonly string[] {
+  // Peers we hold a link to, deduplicated, since one peer reached over two
+  // transports, or over both Bluetooth roles, is still one peer. `kind` narrows
+  // to peers reachable on that transport.
+  //
+  // Order matters to both callers: a sync request is link-local, so asking a
+  // peer three hops away wastes a write, and couriers are the first few of
+  // these.
+  directPeers(kind?: TransportKind): readonly string[] {
     const peers: string[] = [];
     const seen = new Set<string>();
-    for (const linkID of this.linkIDs()) {
+    for (const linkID of this.linkIDs(kind)) {
       const peerID = this.peerByLink.get(linkID);
       if (peerID === undefined || seen.has(peerID)) continue;
       seen.add(peerID);
@@ -227,8 +230,26 @@ export class LinkRegistry {
     return peers;
   }
 
-  // The mesh's degree: the flood router scales relay jitter by it, and the
-  // announce reports it so a receiver can tell a crowded room from an empty one.
+  // How crowded the mesh looks. The flood router scales relay jitter and the
+  // time-critical TTL cap by it.
+  //
+  // Peers, not links, and Bluetooth only. Both halves matter and both match
+  // bitchat, whose degree is `peerRegistry.connectedCount`:
+  //
+  //   * Peers, because Bluetooth is dual-role. Two phones that meet each dial
+  //     the other, so one neighbour is two links, and counting links reads a
+  //     room as twice as crowded as it is.
+  //   * Bluetooth, because the delay exists for radio contention. Every phone
+  //     in earshot hears a packet at the same instant and rebroadcasting
+  //     together drowns the room out. A socket on another transport does not
+  //     compete for that airtime, so counting it slows the radio down for no
+  //     reason.
+  degree(): number {
+    return this.directPeers("ble").length;
+  }
+
+  // Open links. Distinct from `degree`: this counts sockets we hold, which is
+  // what the announce reports and what the diagnostics screen shows.
   size(kind?: TransportKind): number {
     if (kind === undefined) return this.kindByLink.size;
     let count = 0;

--- a/src/features/settings/sections/diagnostics-screen.tsx
+++ b/src/features/settings/sections/diagnostics-screen.tsx
@@ -16,6 +16,10 @@
 // Every number is live. Peers come from the same store the Mesh tab renders, so
 // what is shown here and what is shown there can never disagree.
 
+import {
+  TRANSPORT_KINDS,
+  type TransportKind,
+} from "@core/mesh/links/link-registry";
 import { GCS_MAX_BYTES, GCS_TARGET_FPR } from "@core/mesh/sync/gossip-sync";
 import { t, useT } from "@i18n";
 import { getMeshService } from "@services/mesh-service";
@@ -61,6 +65,10 @@ function wifiLabel(state: string): string {
   }
 }
 
+const EMPTY_LINK_COUNTS = Object.fromEntries(
+  TRANSPORT_KINDS.map((kind) => [kind, 0]),
+) as Record<TransportKind, number>;
+
 export default function DiagnosticsScreen({
   onBack,
 }: Props): React.JSX.Element {
@@ -71,6 +79,7 @@ export default function DiagnosticsScreen({
 
   const peers = usePeerStore((s) => s.peers);
   const wifiFastPath = useMeshStateStore((s) => s.wifiFastPath);
+  const lanState = useMeshStateStore((s) => s.lanState);
   const nostrConnected = useMeshStateStore((s) => s.nostrConnected);
 
   // Counters live on the service rather than in a store, so they are polled.
@@ -95,7 +104,7 @@ export default function DiagnosticsScreen({
       return (b.rssi ?? -999) - (a.rssi ?? -999);
     });
 
-  const links = counters.links.ble + counters.links.wifi;
+  const links = Object.values(counters.links).reduce((a, b) => a + b, 0);
 
   return (
     <View style={styles.container}>
@@ -124,17 +133,6 @@ export default function DiagnosticsScreen({
             />
             <GroupDivider />
             <SettingRow
-              icon="share-2"
-              label={T("settings.diag.lan")}
-              description={T("settings.diag.lan_desc")}
-              control={
-                <Text style={styles.comingSoon}>
-                  {T("settings.coming_soon")}
-                </Text>
-              }
-            />
-            <GroupDivider />
-            <SettingRow
               icon="wifi"
               label={T("settings.diag.wifi")}
               description={`${t("settings.diag.wifi_about")} · ${wifiLabel(
@@ -143,6 +141,25 @@ export default function DiagnosticsScreen({
               control={
                 <Text style={[styles.settingValue, styles.settingValueMono]}>
                   {formatNumber(counters.links.wifi)}
+                </Text>
+              }
+            />
+            <GroupDivider />
+            {/* Below Wi-Fi Aware, since that is the faster of the two local
+                paths and the one a reader checks first. "Off" is appended the
+                way the Wi-Fi row appends its state, so a count of zero is not
+                read as "nobody here" on a transport nobody switched on. */}
+            <SettingRow
+              icon="share-2"
+              label={T("settings.diag.lan")}
+              description={
+                lanState === "off"
+                  ? `${t("settings.diag.lan_desc")} · ${t("common.off")}`
+                  : T("settings.diag.lan_desc")
+              }
+              control={
+                <Text style={[styles.settingValue, styles.settingValueMono]}>
+                  {formatNumber(counters.links.lan)}
                 </Text>
               }
             />
@@ -272,12 +289,12 @@ export default function DiagnosticsScreen({
 
 function readSnapshot(): {
   now: number;
-  links: { ble: number; wifi: number };
+  links: Record<TransportKind, number>;
 } {
   const service = getMeshService();
   return {
     now: Date.now(),
-    links: service?.getLinkCounts() ?? { ble: 0, wifi: 0 },
+    links: service?.getLinkCounts() ?? EMPTY_LINK_COUNTS,
   };
 }
 

--- a/src/features/settings/sections/network-screen.tsx
+++ b/src/features/settings/sections/network-screen.tsx
@@ -2,6 +2,29 @@
 // Aware pairing that the same-platform fast path needs, and the always-on
 // bitchat wire compatibility.
 
+// What the LAN row says, per state the controller can report.
+//
+// "searching" deliberately reads as an empty network rather than as a fault.
+// Most venue WiFi blocks peer-to-peer traffic at the access point, and nothing
+// in the app can tell that apart from nobody being there, so the copy must not
+// claim to know which it is.
+function lanStatusText(state: LanState): string {
+  switch (state) {
+    case "active":
+      return t("settings.network.lan_active");
+    case "searching":
+      return t("settings.network.lan_searching");
+    case "unavailable":
+      return t("settings.network.lan_unavailable");
+    case "permission":
+      return t("settings.network.lan_permission");
+    case "unsupported":
+      return t("settings.network.lan_unsupported");
+    case "off":
+      return t("common.off");
+  }
+}
+
 import {
   DEFAULT_DM_RELAYS,
   MAX_CUSTOM_RELAYS,
@@ -10,16 +33,23 @@ import {
   validateRelayUrl,
 } from "@core/nostr/geo-relay";
 import Feather from "@expo/vector-icons/Feather";
-import { useT } from "@i18n";
+import { t, useT } from "@i18n";
 import { getMeshService } from "@services/mesh-service";
 import { presentWiFiPairing } from "@services/wifi-pairing-service";
 import { showAlert } from "@store/alert-store";
-import { useMeshStateStore } from "@store/mesh-state-store";
+import { type LanState, useMeshStateStore } from "@store/mesh-state-store";
 import { useSettingsStore } from "@store/settings-store";
 import { HIT_SLOP, useThemeColors } from "@ui/theme";
 import { formatNumber } from "@utils/format";
 import React, { useState } from "react";
-import { Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import {
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
 import {
   GroupDivider,
   SettingLinkRow,
@@ -45,6 +75,9 @@ export default function NetworkScreen({ onBack }: Props): React.JSX.Element {
   // the section is absent rather than showing a control that cannot work.
   const pairingSupported = useMeshStateStore((s) => s.wifiPairingSupported);
   const pairedCount = useMeshStateStore((s) => s.wifiPairedCount);
+  const lanState = useMeshStateStore((s) => s.lanState);
+  const lanEnabled = useSettingsStore((s) => s.lanTransportEnabled);
+  const setLanEnabled = useSettingsStore((s) => s.setLanTransportEnabled);
   const internetEnabled = useSettingsStore((s) => s.internetEnabled);
   const setInternetEnabled = useSettingsStore((s) => s.setInternetEnabled);
   const geoRelayDiscovery = useSettingsStore((s) => s.geoRelayDiscovery);
@@ -178,6 +211,9 @@ export default function NetworkScreen({ onBack }: Props): React.JSX.Element {
         showsVerticalScrollIndicator={false}
       >
         <View style={styles.section}>
+          <Text style={styles.sectionTitle}>
+            {T("settings.group.internet")}
+          </Text>
           <View style={styles.settingsGroup}>
             <SettingRow
               icon="cloud"
@@ -396,6 +432,47 @@ export default function NetworkScreen({ onBack }: Props): React.JSX.Element {
               description={T("settings.network.bitchat_desc")}
               control={<SettingSwitch value={true} disabled />}
             />
+          </View>
+        </View>
+
+        {/* The one transport that is off by default. Publishing an mDNS record
+            tells every device on the network, and whoever runs it, that this
+            phone is carrying Airhop, so the description says that rather than
+            selling the speed. */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>{T("settings.group.local")}</Text>
+          <View style={styles.settingsGroup}>
+            <SettingRow
+              icon="wifi"
+              label={T("settings.network.lan")}
+              description={T("settings.network.lan_desc")}
+              control={
+                <SettingSwitch
+                  value={lanEnabled}
+                  onValueChange={setLanEnabled}
+                  disabled={lanState === "unsupported"}
+                />
+              }
+            />
+            {lanEnabled && (
+              <>
+                <GroupDivider />
+                <SettingRow
+                  icon="activity"
+                  label={T("settings.status.title")}
+                  description={lanStatusText(lanState)}
+                />
+              </>
+            )}
+            {lanEnabled && Platform.OS === "ios" && (
+              <>
+                <GroupDivider />
+                <SettingRow
+                  icon="moon"
+                  label={T("settings.network.lan_foreground")}
+                />
+              </>
+            )}
           </View>
         </View>
 

--- a/src/features/settings/sections/privacy-screen.tsx
+++ b/src/features/settings/sections/privacy-screen.tsx
@@ -66,6 +66,15 @@ const SECTIONS: LegalSection[] = [
     ],
   },
   {
+    heading: "Local network (optional)",
+    paragraphs: [
+      "Airhop can carry the mesh over a WiFi network you are already joined to, which is the only way an iPhone and an Android phone reach each other without Bluetooth. Finding other devices uses mDNS, the same mechanism a printer uses to appear on a network.",
+      "**An mDNS announcement is readable by every device on that network, and by whoever runs it.** Network equipment commonly logs it, so on a workplace, campus, hotel or venue network this can tell the operator that a device there is running Airhop, with a timestamp. Bluetooth reaches only as far as the radio does and is not recorded by infrastructure.",
+      "What the announcement contains is deliberately empty of history: **a random name, generated fresh each time the transport starts.** It is never your peer ID or any other lasting identifier, so records from two different networks cannot be matched to show the same phone was on both. Your identity is proven only after a connection is made, inside the same encryption every other transport uses.",
+      "Message contents are unaffected: they stay end-to-end encrypted exactly as over Bluetooth. What the network operator can observe is that connections exist, when, and roughly how much data moves, in the way any network operator can. Local network is off by default and stays off until you turn it on.",
+    ],
+  },
+  {
     heading: "Nostr and the internet (optional)",
     paragraphs: [
       "When Airhop uses the internet, it connects to public or user-selected Nostr relays to extend conversations beyond Bluetooth range.",

--- a/src/i18n/locales/am.ts
+++ b/src/i18n/locales/am.ts
@@ -1462,10 +1462,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "የመተላለፊያ መንገዶች",
+  "settings.group.internet": "ኢንተርኔት",
   "settings.group.nearby": "በአቅራቢያ",
   "settings.group.sync": "ማመሳሰል",
   "settings.group.features": "ባህሪያት",
   "settings.group.messages": "መልእክቶች",
+  "settings.group.local": "አካባቢያዊ",
   "settings.group.media": "ሚዲያ",
   "settings.group.reset": "ዳግም ማስጀመር",
   "settings.group.always_on": "ሁልጊዜ በርቷል",
@@ -1620,6 +1622,15 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "ያ አስተላላፊ አስቀድሞ በዝርዝርህ ውስጥ ነው።",
   "settings.network.relay_invalid":
     "ትክክለኛ የአስተላላፊ አድራሻ አስገባ፤ ለምሳሌ relay.example.com። ወደብ የሚያስፈልገው አስተላላፊው ነባሪውን የማይጠቀም ከሆነ ብቻ ነው። የIP አድራሻዎችና የአካባቢ ስሞች አይፈቀዱም።",
+  "settings.network.lan": "የአካባቢ አውታረ መረብ",
+  "settings.network.lan_desc":
+    "በተመሳሳይ WiFi ላይ ያሉ ሰዎችን ያግኙ፣ በiPhone እና Android መካከልም ጭምር። በአውታረ መረቡ ላይ ያሉ ሌሎች መሣሪያዎች Airhop እያሄዱ መሆንዎን ማየት ይችላሉ።",
+  "settings.network.lan_searching": "በዚህ አውታረ መረብ ላይ ምንም የAirhop መሣሪያ የለም",
+  "settings.network.lan_active": "በዚህ አውታረ መረብ ላይ ተገናኝቷል",
+  "settings.network.lan_unavailable": "በWiFi አውታረ መረብ ላይ አይደለም",
+  "settings.network.lan_permission": "የAirhop የአካባቢ አውታረ መረብ መዳረሻ ጠፍቷል",
+  "settings.network.lan_unsupported": "በዚህ መሣሪያ ላይ አይገኝም",
+  "settings.network.lan_foreground": "Airhop በጀርባ ሲሆን ይቆማል። ብሉቱዝ መስራቱን ይቀጥላል።",
   "settings.network.wifi_pair": "ማጣመር",
   "settings.network.wifi_paired": "የተጣመሩ መሣሪያዎች",
   "settings.network.wifi_pair_find": "መሣሪያ ፈልግ",

--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -1515,10 +1515,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "وسائل النقل",
+  "settings.group.internet": "الإنترنت",
   "settings.group.nearby": "بالجوار",
   "settings.group.sync": "المزامنة",
   "settings.group.features": "الميزات",
   "settings.group.messages": "الرسائل",
+  "settings.group.local": "محلي",
   "settings.group.media": "الوسائط",
   "settings.group.reset": "إعادة الضبط",
   "settings.group.always_on": "مفعّل دائمًا",
@@ -1676,6 +1678,17 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "هذا المُرحِّل موجود في قائمتك بالفعل.",
   "settings.network.relay_invalid":
     "أدخل مضيف مُرحِّل صالحًا، مثل relay.example.com. المنفذ مطلوب فقط إن كان المُرحِّل لا يستخدم الافتراضي. عناوين IP والأسماء المحلية غير مسموح بها.",
+  "settings.network.lan": "الشبكة المحلية",
+  "settings.network.lan_desc":
+    "تواصل مع من هم على شبكة WiFi نفسها، بما في ذلك بين iPhone وAndroid. يمكن للأجهزة الأخرى على الشبكة أن ترى أنك تشغّل Airhop.",
+  "settings.network.lan_searching": "لا توجد أجهزة Airhop على هذه الشبكة",
+  "settings.network.lan_active": "متصل على هذه الشبكة",
+  "settings.network.lan_unavailable": "لست على شبكة WiFi",
+  "settings.network.lan_permission":
+    "الوصول إلى الشبكة المحلية معطّل لتطبيق Airhop",
+  "settings.network.lan_unsupported": "غير متاح على هذا الجهاز",
+  "settings.network.lan_foreground":
+    "يتوقف عندما يكون Airhop في الخلفية. تبقى البلوتوث تعمل.",
   "settings.network.wifi_pair": "الاقتران",
   "settings.network.wifi_paired": "الأجهزة المقترنة",
   "settings.network.wifi_pair_find": "ابحث عن جهاز",

--- a/src/i18n/locales/bn.ts
+++ b/src/i18n/locales/bn.ts
@@ -1549,10 +1549,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "বাহন",
+  "settings.group.internet": "ইন্টারনেট",
   "settings.group.nearby": "কাছে",
   "settings.group.sync": "মিলকরণ",
   "settings.group.features": "সুবিধা",
   "settings.group.messages": "বার্তা",
+  "settings.group.local": "স্থানীয়",
   "settings.group.media": "মিডিয়া",
   "settings.group.reset": "রিসেট",
   "settings.group.always_on": "সবসময় চালু",
@@ -1714,6 +1716,17 @@ export const strings: Strings = {
     "সেই রিলেটি ইতিমধ্যেই আপনার তালিকায় আছে।",
   "settings.network.relay_invalid":
     "একটি কাজের রিলে হোস্ট লিখুন, যেমন relay.example.com। রিলে আদি পোর্ট ব্যবহার না করলেই কেবল পোর্ট লাগে। IP ঠিকানা ও স্থানীয় নাম চলবে না।",
+  "settings.network.lan": "স্থানীয় নেটওয়ার্ক",
+  "settings.network.lan_desc":
+    "একই WiFi-তে থাকা লোকদের কাছে পৌঁছান, iPhone ও Android-এর মধ্যেও। নেটওয়ার্কের অন্য ডিভাইসগুলো দেখতে পাবে যে আপনি Airhop চালাচ্ছেন।",
+  "settings.network.lan_searching": "এই নেটওয়ার্কে কোনো Airhop ডিভাইস নেই",
+  "settings.network.lan_active": "এই নেটওয়ার্কে সংযুক্ত",
+  "settings.network.lan_unavailable": "কোনো WiFi নেটওয়ার্কে নেই",
+  "settings.network.lan_permission":
+    "Airhop-এর জন্য স্থানীয় নেটওয়ার্ক অ্যাক্সেস বন্ধ",
+  "settings.network.lan_unsupported": "এই ডিভাইসে উপলব্ধ নয়",
+  "settings.network.lan_foreground":
+    "Airhop ব্যাকগ্রাউন্ডে গেলে থেমে যায়। ব্লুটুথ চলতে থাকে।",
   "settings.network.wifi_pair": "জোড়া লাগানো",
   "settings.network.wifi_paired": "জোড়া লাগানো ডিভাইস",
   "settings.network.wifi_pair_find": "একটি ডিভাইস খুঁজুন",

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1601,10 +1601,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "Übertragungswege",
+  "settings.group.internet": "Internet",
   "settings.group.nearby": "In der Nähe",
   "settings.group.sync": "Sync",
   "settings.group.features": "Funktionen",
   "settings.group.messages": "Nachrichten",
+  "settings.group.local": "Lokal",
   "settings.group.media": "Medien",
   "settings.group.reset": "Zurücksetzen",
   "settings.group.always_on": "Immer an",
@@ -1769,6 +1771,17 @@ export const strings: Strings = {
     "Dieses Relay steht bereits in deiner Liste.",
   "settings.network.relay_invalid":
     "Gib einen gültigen Relay-Host ein, z. B. relay.example.com. Ein Port ist nur nötig, wenn das Relay nicht den Standard verwendet. IP-Adressen und lokale Namen sind nicht erlaubt.",
+  "settings.network.lan": "Lokales Netzwerk",
+  "settings.network.lan_desc":
+    "Erreiche Leute im selben WLAN, auch zwischen iPhone und Android. Andere Geräte im Netzwerk können sehen, dass du Airhop verwendest.",
+  "settings.network.lan_searching": "Keine Airhop-Geräte in diesem Netzwerk",
+  "settings.network.lan_active": "In diesem Netzwerk verbunden",
+  "settings.network.lan_unavailable": "In keinem WLAN",
+  "settings.network.lan_permission":
+    "Der Zugriff aufs lokale Netzwerk ist für Airhop deaktiviert",
+  "settings.network.lan_unsupported": "Auf diesem Gerät nicht verfügbar",
+  "settings.network.lan_foreground":
+    "Pausiert, wenn Airhop im Hintergrund ist. Bluetooth läuft weiter.",
   "settings.network.wifi_pair": "Kopplung",
   "settings.network.wifi_paired": "Gekoppelte Geräte",
   "settings.network.wifi_pair_find": "Gerät finden",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1579,10 +1579,12 @@ export const strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "Transports",
+  "settings.group.internet": "Internet",
   "settings.group.nearby": "Nearby",
   "settings.group.sync": "Sync",
   "settings.group.features": "Features",
   "settings.group.messages": "Messages",
+  "settings.group.local": "Local",
   "settings.group.media": "Media",
   "settings.group.reset": "Reset",
   "settings.group.always_on": "Always on",
@@ -1739,6 +1741,16 @@ export const strings = {
   "settings.network.relay_duplicate": "That relay is already in your list.",
   "settings.network.relay_invalid":
     "Enter a valid relay host, e.g. relay.example.com. A port is only needed if the relay does not use the default. IP addresses and local names are not allowed.",
+  "settings.network.lan": "Local network",
+  "settings.network.lan_desc":
+    "Reach people on the same WiFi, including across iPhone and Android. Other devices on the network can see that you are running Airhop.",
+  "settings.network.lan_searching": "No Airhop devices on this network",
+  "settings.network.lan_active": "Connected on this network",
+  "settings.network.lan_unavailable": "Not on a WiFi network",
+  "settings.network.lan_permission": "Local network access is off for Airhop",
+  "settings.network.lan_unsupported": "Not available on this device",
+  "settings.network.lan_foreground":
+    "Pauses when Airhop is in the background. Bluetooth keeps running.",
   "settings.network.wifi_pair": "Pairing",
   "settings.network.wifi_paired": "Paired devices",
   "settings.network.wifi_pair_find": "Find a device",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1594,10 +1594,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "Transportes",
+  "settings.group.internet": "Internet",
   "settings.group.nearby": "Cerca",
   "settings.group.sync": "Sincronización",
   "settings.group.features": "Funciones",
   "settings.group.messages": "Mensajes",
+  "settings.group.local": "Local",
   "settings.group.media": "Medios",
   "settings.group.reset": "Restablecer",
   "settings.group.always_on": "Siempre activo",
@@ -1762,6 +1764,17 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "Ese relé ya está en tu lista.",
   "settings.network.relay_invalid":
     "Introduce un host de relé válido, por ejemplo relay.example.com. El puerto solo hace falta si el relé no usa el predeterminado. No se admiten direcciones IP ni nombres locales.",
+  "settings.network.lan": "Red local",
+  "settings.network.lan_desc":
+    "Llega a quienes están en la misma WiFi, incluso entre iPhone y Android. Otros dispositivos de la red pueden ver que usas Airhop.",
+  "settings.network.lan_searching": "No hay dispositivos Airhop en esta red",
+  "settings.network.lan_active": "Conectado en esta red",
+  "settings.network.lan_unavailable": "No estás en una red WiFi",
+  "settings.network.lan_permission":
+    "El acceso a la red local está desactivado para Airhop",
+  "settings.network.lan_unsupported": "No disponible en este dispositivo",
+  "settings.network.lan_foreground":
+    "Se pausa cuando Airhop está en segundo plano. El Bluetooth sigue funcionando.",
   "settings.network.wifi_pair": "Vinculación",
   "settings.network.wifi_paired": "Dispositivos vinculados",
   "settings.network.wifi_pair_find": "Buscar un dispositivo",

--- a/src/i18n/locales/fa.ts
+++ b/src/i18n/locales/fa.ts
@@ -1561,10 +1561,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "بسترهای انتقال",
+  "settings.group.internet": "اینترنت",
   "settings.group.nearby": "نزدیک",
   "settings.group.sync": "همگام‌سازی",
   "settings.group.features": "قابلیت‌ها",
   "settings.group.messages": "پیام‌ها",
+  "settings.group.local": "محلی",
   "settings.group.media": "رسانه",
   "settings.group.reset": "بازنشانی",
   "settings.group.always_on": "همیشه روشن",
@@ -1726,6 +1728,17 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "آن رله از پیش در فهرست شماست.",
   "settings.network.relay_invalid":
     "یک میزبان رلهٔ معتبر وارد کنید، مثلاً relay.example.com. درگاه تنها وقتی لازم است که رله از مقدار پیش‌فرض استفاده نکند. نشانی‌های IP و نام‌های محلی مجاز نیستند.",
+  "settings.network.lan": "شبکه محلی",
+  "settings.network.lan_desc":
+    "به افرادی که روی همان WiFi هستند برس، حتی بین iPhone و Android. دستگاه‌های دیگر شبکه می‌توانند ببینند که Airhop را اجرا می‌کنی.",
+  "settings.network.lan_searching": "هیچ دستگاه Airhop روی این شبکه نیست",
+  "settings.network.lan_active": "در این شبکه متصل است",
+  "settings.network.lan_unavailable": "به هیچ شبکه WiFi وصل نیستی",
+  "settings.network.lan_permission":
+    "دسترسی به شبکه محلی برای Airhop خاموش است",
+  "settings.network.lan_unsupported": "روی این دستگاه در دسترس نیست",
+  "settings.network.lan_foreground":
+    "وقتی Airhop در پس‌زمینه باشد متوقف می‌شود. بلوتوث همچنان کار می‌کند.",
   "settings.network.wifi_pair": "جفت‌شدن",
   "settings.network.wifi_paired": "دستگاه‌های جفت‌شده",
   "settings.network.wifi_pair_find": "یافتن یک دستگاه",

--- a/src/i18n/locales/fil.ts
+++ b/src/i18n/locales/fil.ts
@@ -1618,10 +1618,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "Mga Transport",
+  "settings.group.internet": "Internet",
   "settings.group.nearby": "Sa malapit",
   "settings.group.sync": "Sync",
   "settings.group.features": "Mga Feature",
   "settings.group.messages": "Mga Mensahe",
+  "settings.group.local": "Lokal",
   "settings.group.media": "Media",
   "settings.group.reset": "I-reset",
   "settings.group.always_on": "Laging naka-on",
@@ -1788,6 +1790,17 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "Nasa listahan mo na ang relay na iyon.",
   "settings.network.relay_invalid":
     "Maglagay ng wastong host ng relay, hal. relay.example.com. Kailangan lang ng port kung hindi ginagamit ng relay ang default. Hindi pinapayagan ang mga IP address at lokal na pangalan.",
+  "settings.network.lan": "Lokal na network",
+  "settings.network.lan_desc":
+    "Abutin ang mga tao sa iisang WiFi, kasama ang pagitan ng iPhone at Android. Makikita ng ibang device sa network na gumagamit ka ng Airhop.",
+  "settings.network.lan_searching": "Walang Airhop device sa network na ito",
+  "settings.network.lan_active": "Nakakonekta sa network na ito",
+  "settings.network.lan_unavailable": "Wala sa isang WiFi network",
+  "settings.network.lan_permission":
+    "Naka-off ang lokal na network access para sa Airhop",
+  "settings.network.lan_unsupported": "Hindi available sa device na ito",
+  "settings.network.lan_foreground":
+    "Humihinto kapag nasa background ang Airhop. Tuloy ang Bluetooth.",
   "settings.network.wifi_pair": "Pagpapares",
   "settings.network.wifi_paired": "Mga nakapares na device",
   "settings.network.wifi_pair_find": "Maghanap ng device",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1600,10 +1600,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "Transports",
+  "settings.group.internet": "Internet",
   "settings.group.nearby": "À proximité",
   "settings.group.sync": "Synchronisation",
   "settings.group.features": "Fonctions",
   "settings.group.messages": "Messages",
+  "settings.group.local": "Local",
   "settings.group.media": "Médias",
   "settings.group.reset": "Réinitialisation",
   "settings.group.always_on": "Toujours actif",
@@ -1769,6 +1771,17 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "Ce relais est déjà dans ta liste.",
   "settings.network.relay_invalid":
     "Saisis un hôte de relais valide, par exemple relay.example.com. Le port n’est nécessaire que si le relais n’utilise pas celui par défaut. Les adresses IP et les noms locaux ne sont pas acceptés.",
+  "settings.network.lan": "Réseau local",
+  "settings.network.lan_desc":
+    "Joignez les personnes sur le même WiFi, y compris entre iPhone et Android. Les autres appareils du réseau peuvent voir que vous utilisez Airhop.",
+  "settings.network.lan_searching": "Aucun appareil Airhop sur ce réseau",
+  "settings.network.lan_active": "Connecté sur ce réseau",
+  "settings.network.lan_unavailable": "Pas sur un réseau WiFi",
+  "settings.network.lan_permission":
+    "L’accès au réseau local est désactivé pour Airhop",
+  "settings.network.lan_unsupported": "Non disponible sur cet appareil",
+  "settings.network.lan_foreground":
+    "S’interrompt quand Airhop passe en arrière-plan. Le Bluetooth continue.",
   "settings.network.wifi_pair": "Jumelage",
   "settings.network.wifi_paired": "Appareils jumelés",
   "settings.network.wifi_pair_find": "Trouver un appareil",

--- a/src/i18n/locales/hi.ts
+++ b/src/i18n/locales/hi.ts
@@ -1553,10 +1553,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "ट्रांसपोर्ट",
+  "settings.group.internet": "इंटरनेट",
   "settings.group.nearby": "आस-पास",
   "settings.group.sync": "सिंक",
   "settings.group.features": "सुविधाएँ",
   "settings.group.messages": "संदेश",
+  "settings.group.local": "स्थानीय",
   "settings.group.media": "मीडिया",
   "settings.group.reset": "रीसेट",
   "settings.group.always_on": "हमेशा चालू",
@@ -1717,6 +1719,17 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "वह रिले पहले से आपकी सूची में है।",
   "settings.network.relay_invalid":
     "कोई मान्य रिले होस्ट डालें, जैसे relay.example.com। पोर्ट तभी चाहिए जब रिले डिफ़ॉल्ट इस्तेमाल न करता हो। IP पते और स्थानीय नाम मान्य नहीं हैं।",
+  "settings.network.lan": "स्थानीय नेटवर्क",
+  "settings.network.lan_desc":
+    "उसी WiFi पर मौजूद लोगों तक पहुँचें, iPhone और Android के बीच भी। नेटवर्क पर मौजूद दूसरे डिवाइस देख सकते हैं कि आप Airhop चला रहे हैं।",
+  "settings.network.lan_searching": "इस नेटवर्क पर कोई Airhop डिवाइस नहीं",
+  "settings.network.lan_active": "इस नेटवर्क पर जुड़ा हुआ",
+  "settings.network.lan_unavailable": "किसी WiFi नेटवर्क पर नहीं",
+  "settings.network.lan_permission":
+    "Airhop के लिए स्थानीय नेटवर्क एक्सेस बंद है",
+  "settings.network.lan_unsupported": "इस डिवाइस पर उपलब्ध नहीं",
+  "settings.network.lan_foreground":
+    "Airhop के बैकग्राउंड में जाने पर रुक जाता है। ब्लूटूथ चलता रहता है।",
   "settings.network.wifi_pair": "पेयरिंग",
   "settings.network.wifi_paired": "पेयर किए गए डिवाइस",
   "settings.network.wifi_pair_find": "डिवाइस ढूँढें",

--- a/src/i18n/locales/id.ts
+++ b/src/i18n/locales/id.ts
@@ -1578,10 +1578,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "Pengangkut",
+  "settings.group.internet": "Internet",
   "settings.group.nearby": "Di dekat sini",
   "settings.group.sync": "Sinkronisasi",
   "settings.group.features": "Fitur",
   "settings.group.messages": "Pesan",
+  "settings.group.local": "Lokal",
   "settings.group.media": "Media",
   "settings.group.reset": "Setel ulang",
   "settings.group.always_on": "Selalu menyala",
@@ -1745,6 +1747,18 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "Relai itu sudah ada di daftarmu.",
   "settings.network.relay_invalid":
     "Masukkan host relai yang sah, misalnya relay.example.com. Porta hanya perlu kalau relainya tidak memakai porta bawaan. Alamat IP dan nama lokal tidak diizinkan.",
+  "settings.network.lan": "Jaringan lokal",
+  "settings.network.lan_desc":
+    "Jangkau orang di WiFi yang sama, termasuk antara iPhone dan Android. Perangkat lain di jaringan dapat melihat bahwa kamu menjalankan Airhop.",
+  "settings.network.lan_searching":
+    "Tidak ada perangkat Airhop di jaringan ini",
+  "settings.network.lan_active": "Terhubung di jaringan ini",
+  "settings.network.lan_unavailable": "Tidak berada di jaringan WiFi",
+  "settings.network.lan_permission":
+    "Akses jaringan lokal nonaktif untuk Airhop",
+  "settings.network.lan_unsupported": "Tidak tersedia di perangkat ini",
+  "settings.network.lan_foreground":
+    "Berhenti saat Airhop di latar belakang. Bluetooth tetap berjalan.",
   "settings.network.wifi_pair": "Penyandingan",
   "settings.network.wifi_paired": "Perangkat tersanding",
   "settings.network.wifi_pair_find": "Cari perangkat",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1593,10 +1593,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "Trasporti",
+  "settings.group.internet": "Internet",
   "settings.group.nearby": "Vicinanze",
   "settings.group.sync": "Sincronizzazione",
   "settings.group.features": "Funzioni",
   "settings.group.messages": "Messaggi",
+  "settings.group.local": "Locale",
   "settings.group.media": "Media",
   "settings.group.reset": "Ripristino",
   "settings.group.always_on": "Sempre attivo",
@@ -1765,6 +1767,17 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "Quel relay è già nel tuo elenco.",
   "settings.network.relay_invalid":
     "Inserisci un host relay valido, ad esempio relay.example.com. La porta serve solo se il relay non usa quella predefinita. Gli indirizzi IP e i nomi locali non sono ammessi.",
+  "settings.network.lan": "Rete locale",
+  "settings.network.lan_desc":
+    "Raggiungi le persone sulla stessa WiFi, anche tra iPhone e Android. Gli altri dispositivi sulla rete possono vedere che stai usando Airhop.",
+  "settings.network.lan_searching": "Nessun dispositivo Airhop su questa rete",
+  "settings.network.lan_active": "Connesso su questa rete",
+  "settings.network.lan_unavailable": "Non sei su una rete WiFi",
+  "settings.network.lan_permission":
+    "L’accesso alla rete locale è disattivato per Airhop",
+  "settings.network.lan_unsupported": "Non disponibile su questo dispositivo",
+  "settings.network.lan_foreground":
+    "Si interrompe quando Airhop è in background. Il Bluetooth continua.",
   "settings.network.wifi_pair": "Abbinamento",
   "settings.network.wifi_paired": "Dispositivi abbinati",
   "settings.network.wifi_pair_find": "Trova un dispositivo",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -1565,10 +1565,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "通信経路",
+  "settings.group.internet": "インターネット",
   "settings.group.nearby": "近く",
   "settings.group.sync": "同期",
   "settings.group.features": "機能",
   "settings.group.messages": "メッセージ",
+  "settings.group.local": "ローカル",
   "settings.group.media": "メディア",
   "settings.group.reset": "リセット",
   "settings.group.always_on": "常時オン",
@@ -1728,6 +1730,18 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "そのリレーはすでに一覧にあります。",
   "settings.network.relay_invalid":
     "relay.example.comのような有効なリレーのホスト名を入力してください。ポートは、リレーが既定のポートを使っていない場合にのみ必要です。IPアドレスやローカル名は使えません。",
+  "settings.network.lan": "ローカルネットワーク",
+  "settings.network.lan_desc":
+    "同じWiFi上の相手に届きます。iPhoneとAndroidの間でも使えます。ネットワーク上の他の端末からは、Airhopを使っていることが見えます。",
+  "settings.network.lan_searching":
+    "このネットワークにAirhopの端末はありません",
+  "settings.network.lan_active": "このネットワークで接続中",
+  "settings.network.lan_unavailable": "WiFiネットワークに接続していません",
+  "settings.network.lan_permission":
+    "Airhopのローカルネットワークアクセスがオフです",
+  "settings.network.lan_unsupported": "この端末では利用できません",
+  "settings.network.lan_foreground":
+    "Airhopがバックグラウンドになると停止します。Bluetoothは動き続けます。",
   "settings.network.wifi_pair": "ペアリング",
   "settings.network.wifi_paired": "ペアリング済みデバイス",
   "settings.network.wifi_pair_find": "デバイスを探す",

--- a/src/i18n/locales/ka.ts
+++ b/src/i18n/locales/ka.ts
@@ -1576,10 +1576,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "გადამზიდები",
+  "settings.group.internet": "ინტერნეტი",
   "settings.group.nearby": "ახლოს",
   "settings.group.sync": "სინქრონიზაცია",
   "settings.group.features": "ფუნქციები",
   "settings.group.messages": "შეტყობინებები",
+  "settings.group.local": "ლოკალური",
   "settings.group.media": "მედია",
   "settings.group.reset": "საწყისზე დაბრუნება",
   "settings.group.always_on": "ყოველთვის ჩართული",
@@ -1744,6 +1746,17 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "ეს რელე უკვე შენს სიაშია.",
   "settings.network.relay_invalid":
     "შეიყვანე რელეს სწორი ჰოსტი, მაგალითად relay.example.com. პორტი მხოლოდ მაშინაა საჭირო, თუ რელე ნაგულისხმევს არ იყენებს. IP მისამართები და ლოკალური სახელები დაუშვებელია.",
+  "settings.network.lan": "ლოკალური ქსელი",
+  "settings.network.lan_desc":
+    "მიაღწიე იმავე WiFi-ზე მყოფებს, iPhone-სა და Android-ს შორისაც. ქსელის სხვა მოწყობილობებს შეუძლიათ დაინახონ, რომ Airhop-ს იყენებ.",
+  "settings.network.lan_searching": "ამ ქსელში Airhop-ის მოწყობილობა არ არის",
+  "settings.network.lan_active": "დაკავშირებულია ამ ქსელში",
+  "settings.network.lan_unavailable": "არ ხარ WiFi ქსელში",
+  "settings.network.lan_permission":
+    "ლოკალურ ქსელზე წვდომა Airhop-ისთვის გამორთულია",
+  "settings.network.lan_unsupported": "ამ მოწყობილობაზე მიუწვდომელია",
+  "settings.network.lan_foreground":
+    "ჩერდება, როცა Airhop ფონურ რეჟიმშია. Bluetooth აგრძელებს მუშაობას.",
   "settings.network.wifi_pair": "დაწყვილება",
   "settings.network.wifi_paired": "დაწყვილებული მოწყობილობები",
   "settings.network.wifi_pair_find": "მოწყობილობის პოვნა",

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -1541,10 +1541,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "전송 방식",
+  "settings.group.internet": "인터넷",
   "settings.group.nearby": "근처",
   "settings.group.sync": "동기화",
   "settings.group.features": "기능",
   "settings.group.messages": "메시지",
+  "settings.group.local": "로컬",
   "settings.group.media": "미디어",
   "settings.group.reset": "초기화",
   "settings.group.always_on": "항상 켜짐",
@@ -1701,6 +1703,17 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "그 릴레이는 이미 목록에 있습니다.",
   "settings.network.relay_invalid":
     "relay.example.com 같은 올바른 릴레이 호스트를 입력하세요. 포트는 릴레이가 기본값을 쓰지 않을 때만 필요합니다. IP 주소와 로컬 이름은 허용되지 않습니다.",
+  "settings.network.lan": "로컬 네트워크",
+  "settings.network.lan_desc":
+    "같은 WiFi에 있는 사람에게 연결합니다. iPhone과 Android 사이에서도 됩니다. 네트워크의 다른 기기는 당신이 Airhop을 쓰고 있다는 것을 볼 수 있습니다.",
+  "settings.network.lan_searching": "이 네트워크에 Airhop 기기가 없습니다",
+  "settings.network.lan_active": "이 네트워크에서 연결됨",
+  "settings.network.lan_unavailable": "WiFi 네트워크에 있지 않습니다",
+  "settings.network.lan_permission":
+    "Airhop의 로컬 네트워크 접근이 꺼져 있습니다",
+  "settings.network.lan_unsupported": "이 기기에서는 사용할 수 없습니다",
+  "settings.network.lan_foreground":
+    "Airhop이 백그라운드로 가면 멈춥니다. 블루투스는 계속 작동합니다.",
   "settings.network.wifi_pair": "페어링",
   "settings.network.wifi_paired": "페어링된 기기",
   "settings.network.wifi_pair_find": "기기 찾기",

--- a/src/i18n/locales/mg.ts
+++ b/src/i18n/locales/mg.ts
@@ -1612,10 +1612,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "Fitaterana",
+  "settings.group.internet": "Aterineto",
   "settings.group.nearby": "Akaiky",
   "settings.group.sync": "Fampifanarahana",
   "settings.group.features": "Fiasa",
   "settings.group.messages": "Hafatra",
+  "settings.group.local": "Eo an-toerana",
   "settings.group.media": "Media",
   "settings.group.reset": "Famerenana",
   "settings.group.always_on": "Mandeha foana",
@@ -1787,6 +1789,18 @@ export const strings: Strings = {
     "Efa ao amin'ny lisitrao io mpanelanelana io.",
   "settings.network.relay_invalid":
     "Soraty ny anaran'ny mpanelanelana mety, ohatra relay.example.com. Mila laharam-pidirana ihany raha tsy mampiasa ny mahazatra ny mpanelanelana. Tsy azo ampiasaina ny adiresy IP sy ny anarana eo an-toerana.",
+  "settings.network.lan": "Tambajotra eo an-toerana",
+  "settings.network.lan_desc":
+    "Tratraro ny olona ao amin'ny WiFi mitovy, na eo amin'ny iPhone sy Android aza. Hitan'ny fitaovana hafa ao amin'ny tambajotra fa mampiasa Airhop ianao.",
+  "settings.network.lan_searching":
+    "Tsy misy fitaovana Airhop amin'ity tambajotra ity",
+  "settings.network.lan_active": "Mifandray amin'ity tambajotra ity",
+  "settings.network.lan_unavailable": "Tsy ao amin'ny tambajotra WiFi",
+  "settings.network.lan_permission":
+    "Vonoina ho an'i Airhop ny fidirana amin'ny tambajotra eo an-toerana",
+  "settings.network.lan_unsupported": "Tsy misy amin'ity fitaovana ity",
+  "settings.network.lan_foreground":
+    "Mijanona rehefa any ambadika i Airhop. Mitohy ny Bluetooth.",
   "settings.network.wifi_pair": "Fampifanarahana",
   "settings.network.wifi_paired": "Fitaovana nampifanarahana",
   "settings.network.wifi_pair_find": "Hitady fitaovana",

--- a/src/i18n/locales/ms.ts
+++ b/src/i18n/locales/ms.ts
@@ -1583,10 +1583,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "Pengangkut",
+  "settings.group.internet": "Internet",
   "settings.group.nearby": "Berdekatan",
   "settings.group.sync": "Penyegerakan",
   "settings.group.features": "Ciri",
   "settings.group.messages": "Mesej",
+  "settings.group.local": "Setempat",
   "settings.group.media": "Media",
   "settings.group.reset": "Tetap semula",
   "settings.group.always_on": "Sentiasa hidup",
@@ -1754,6 +1756,17 @@ export const strings: Strings = {
     "Geganti itu sudah ada dalam senarai anda.",
   "settings.network.relay_invalid":
     "Masukkan hos geganti yang sah, contohnya relay.example.com. Port hanya diperlukan kalau geganti itu tidak menggunakan port lalai. Alamat IP dan nama setempat tidak dibenarkan.",
+  "settings.network.lan": "Rangkaian setempat",
+  "settings.network.lan_desc":
+    "Hubungi orang pada WiFi yang sama, termasuk antara iPhone dan Android. Peranti lain pada rangkaian boleh melihat bahawa anda menggunakan Airhop.",
+  "settings.network.lan_searching": "Tiada peranti Airhop pada rangkaian ini",
+  "settings.network.lan_active": "Bersambung pada rangkaian ini",
+  "settings.network.lan_unavailable": "Tiada pada rangkaian WiFi",
+  "settings.network.lan_permission":
+    "Akses rangkaian setempat dimatikan untuk Airhop",
+  "settings.network.lan_unsupported": "Tidak tersedia pada peranti ini",
+  "settings.network.lan_foreground":
+    "Berhenti apabila Airhop di latar belakang. Bluetooth terus berjalan.",
   "settings.network.wifi_pair": "Gandingan",
   "settings.network.wifi_paired": "Peranti bergandingan",
   "settings.network.wifi_pair_find": "Cari peranti",

--- a/src/i18n/locales/my.ts
+++ b/src/i18n/locales/my.ts
@@ -1599,10 +1599,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "သယ်ဆောင်ရေးလမ်းကြောင်းများ",
+  "settings.group.internet": "အင်တာနက်",
   "settings.group.nearby": "အနီးအနား",
   "settings.group.sync": "ထပ်တူညီစေခြင်း",
   "settings.group.features": "လုပ်ဆောင်ချက်များ",
   "settings.group.messages": "မက်ဆေ့ဂျ်များ",
+  "settings.group.local": "စက်တွင်း",
   "settings.group.media": "မီဒီယာ",
   "settings.group.reset": "ပြန်လည်သတ်မှတ်ခြင်း",
   "settings.group.always_on": "အမြဲဖွင့်ထား",
@@ -1774,6 +1776,17 @@ export const strings: Strings = {
     "ထိုထပ်ဆင့်လွှင့်စက်သည် သင့်စာရင်းတွင် ရှိပြီးသားဖြစ်သည်။",
   "settings.network.relay_invalid":
     "မှန်ကန်သော ထပ်ဆင့်လွှင့်စက်လိပ်စာကို ထည့်ပါ၊ ဥပမာ relay.example.com။ ပို့တ်သည် စက်က မူလတန်ဖိုးကို မသုံးမှသာ လိုအပ်သည်။ IP လိပ်စာများနှင့် ဒေသတွင်းအမည်များကို ခွင့်မပြုပါ။",
+  "settings.network.lan": "စက်တွင်းကွန်ရက်",
+  "settings.network.lan_desc":
+    "တူညီသော WiFi ပေါ်ရှိ လူများထံ ရောက်ရှိပါ၊ iPhone နှင့် Android ကြားတွင်လည်း ရပါသည်။ ကွန်ရက်ပေါ်ရှိ အခြားစက်များက သင် Airhop သုံးနေကြောင်း မြင်နိုင်ပါသည်။",
+  "settings.network.lan_searching": "ဤကွန်ရက်ပေါ်တွင် Airhop စက် မရှိပါ",
+  "settings.network.lan_active": "ဤကွန်ရက်တွင် ချိတ်ဆက်ထားသည်",
+  "settings.network.lan_unavailable": "WiFi ကွန်ရက်ပေါ်တွင် မရှိပါ",
+  "settings.network.lan_permission":
+    "Airhop အတွက် စက်တွင်းကွန်ရက် သုံးခွင့် ပိတ်ထားသည်",
+  "settings.network.lan_unsupported": "ဤစက်တွင် မရရှိနိုင်ပါ",
+  "settings.network.lan_foreground":
+    "Airhop နောက်ကွယ်သို့ ရောက်သောအခါ ရပ်သွားသည်။ ဘလူးတုသ်က ဆက်လက်အလုပ်လုပ်သည်။",
   "settings.network.wifi_pair": "တွဲချိတ်ခြင်း",
   "settings.network.wifi_paired": "တွဲထားသော ကိရိယာများ",
   "settings.network.wifi_pair_find": "ကိရိယာ ရှာပါ",

--- a/src/i18n/locales/ne.ts
+++ b/src/i18n/locales/ne.ts
@@ -1547,10 +1547,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "वाहक",
+  "settings.group.internet": "इन्टरनेट",
   "settings.group.nearby": "नजिकै",
   "settings.group.sync": "समक्रमण",
   "settings.group.features": "सुविधा",
   "settings.group.messages": "सन्देश",
+  "settings.group.local": "स्थानीय",
   "settings.group.media": "मिडिया",
   "settings.group.reset": "रिसेट",
   "settings.group.always_on": "सधैँ खुला",
@@ -1712,6 +1714,17 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "त्यो रिले पहिल्यै तपाईंको सूचीमा छ।",
   "settings.network.relay_invalid":
     "मान्य रिले होस्ट हाल्नुहोस्, जस्तै relay.example.com। रिलेले पूर्वनिर्धारित पोर्ट नचलाएमा मात्र पोर्ट चाहिन्छ। IP ठेगाना र स्थानीय नाम मान्य छैनन्।",
+  "settings.network.lan": "स्थानीय नेटवर्क",
+  "settings.network.lan_desc":
+    "उही WiFi मा भएका मान्छेसम्म पुग्नुहोस्, iPhone र Android बीच पनि। नेटवर्कमा भएका अरू यन्त्रले तपाईं Airhop चलाइरहेको देख्न सक्छन्।",
+  "settings.network.lan_searching": "यो नेटवर्कमा कुनै Airhop यन्त्र छैन",
+  "settings.network.lan_active": "यो नेटवर्कमा जोडिएको",
+  "settings.network.lan_unavailable": "कुनै WiFi नेटवर्कमा छैन",
+  "settings.network.lan_permission":
+    "Airhop का लागि स्थानीय नेटवर्क पहुँच बन्द छ",
+  "settings.network.lan_unsupported": "यो यन्त्रमा उपलब्ध छैन",
+  "settings.network.lan_foreground":
+    "Airhop पृष्ठभूमिमा जाँदा रोकिन्छ। ब्लुटुथ चलिरहन्छ।",
   "settings.network.wifi_pair": "जोडा मिलाउने",
   "settings.network.wifi_paired": "जोडा मिलाइएका उपकरण",
   "settings.network.wifi_pair_find": "उपकरण खोज्नुहोस्",

--- a/src/i18n/locales/nl.ts
+++ b/src/i18n/locales/nl.ts
@@ -1585,10 +1585,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "Transporten",
+  "settings.group.internet": "Internet",
   "settings.group.nearby": "In de buurt",
   "settings.group.sync": "Synchronisatie",
   "settings.group.features": "Functies",
   "settings.group.messages": "Berichten",
+  "settings.group.local": "Lokaal",
   "settings.group.media": "Media",
   "settings.group.reset": "Resetten",
   "settings.group.always_on": "Altijd aan",
@@ -1752,6 +1754,17 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "Die relay staat al in je lijst.",
   "settings.network.relay_invalid":
     "Vul een geldige relayhost in, bijvoorbeeld relay.example.com. Een poort is alleen nodig als de relay niet de standaardpoort gebruikt. IP-adressen en lokale namen zijn niet toegestaan.",
+  "settings.network.lan": "Lokaal netwerk",
+  "settings.network.lan_desc":
+    "Bereik mensen op dezelfde WiFi, ook tussen iPhone en Android. Andere apparaten op het netwerk kunnen zien dat je Airhop gebruikt.",
+  "settings.network.lan_searching": "Geen Airhop-apparaten op dit netwerk",
+  "settings.network.lan_active": "Verbonden op dit netwerk",
+  "settings.network.lan_unavailable": "Niet op een WiFi-netwerk",
+  "settings.network.lan_permission":
+    "Toegang tot het lokale netwerk staat uit voor Airhop",
+  "settings.network.lan_unsupported": "Niet beschikbaar op dit apparaat",
+  "settings.network.lan_foreground":
+    "Pauzeert wanneer Airhop op de achtergrond staat. Bluetooth blijft draaien.",
   "settings.network.wifi_pair": "Koppelen",
   "settings.network.wifi_paired": "Gekoppelde apparaten",
   "settings.network.wifi_pair_find": "Een apparaat zoeken",

--- a/src/i18n/locales/pa.ts
+++ b/src/i18n/locales/pa.ts
@@ -1556,10 +1556,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "ਟ੍ਰਾਂਸਪੋਰਟ",
+  "settings.group.internet": "ਇੰਟਰਨੈੱਟ",
   "settings.group.nearby": "ਨੇੜੇ",
   "settings.group.sync": "ਸਿੰਕ",
   "settings.group.features": "ਸਹੂਲਤਾਂ",
   "settings.group.messages": "ਸੁਨੇਹੇ",
+  "settings.group.local": "ਸਥਾਨਕ",
   "settings.group.media": "ਮੀਡੀਆ",
   "settings.group.reset": "ਮੁੜ-ਸੈੱਟ",
   "settings.group.always_on": "ਹਮੇਸ਼ਾ ਚਾਲੂ",
@@ -1722,6 +1724,16 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "ਉਹ ਰਿਲੇ ਪਹਿਲਾਂ ਹੀ ਤੁਹਾਡੀ ਸੂਚੀ ਵਿੱਚ ਹੈ।",
   "settings.network.relay_invalid":
     "ਸਹੀ ਰਿਲੇ ਹੋਸਟ ਭਰੋ, ਜਿਵੇਂ relay.example.com। ਪੋਰਟ ਸਿਰਫ਼ ਤਾਂ ਹੀ ਚਾਹੀਦਾ ਹੈ ਜੇ ਰਿਲੇ ਮੂਲ ਪੋਰਟ ਨਾ ਵਰਤਦਾ ਹੋਵੇ। IP ਪਤੇ ਅਤੇ ਸਥਾਨਕ ਨਾਂ ਮਨਜ਼ੂਰ ਨਹੀਂ ਹਨ।",
+  "settings.network.lan": "ਸਥਾਨਕ ਨੈੱਟਵਰਕ",
+  "settings.network.lan_desc":
+    "ਉਸੇ WiFi ਉੱਤੇ ਮੌਜੂਦ ਲੋਕਾਂ ਤੱਕ ਪਹੁੰਚੋ, iPhone ਅਤੇ Android ਵਿਚਕਾਰ ਵੀ। ਨੈੱਟਵਰਕ ਉੱਤੇ ਮੌਜੂਦ ਹੋਰ ਡਿਵਾਈਸ ਦੇਖ ਸਕਦੇ ਹਨ ਕਿ ਤੁਸੀਂ Airhop ਚਲਾ ਰਹੇ ਹੋ।",
+  "settings.network.lan_searching": "ਇਸ ਨੈੱਟਵਰਕ ਉੱਤੇ ਕੋਈ Airhop ਡਿਵਾਈਸ ਨਹੀਂ",
+  "settings.network.lan_active": "ਇਸ ਨੈੱਟਵਰਕ ਉੱਤੇ ਜੁੜਿਆ",
+  "settings.network.lan_unavailable": "ਕਿਸੇ WiFi ਨੈੱਟਵਰਕ ਉੱਤੇ ਨਹੀਂ",
+  "settings.network.lan_permission": "Airhop ਲਈ ਸਥਾਨਕ ਨੈੱਟਵਰਕ ਪਹੁੰਚ ਬੰਦ ਹੈ",
+  "settings.network.lan_unsupported": "ਇਸ ਡਿਵਾਈਸ ਉੱਤੇ ਉਪਲਬਧ ਨਹੀਂ",
+  "settings.network.lan_foreground":
+    "Airhop ਦੇ ਬੈਕਗਰਾਊਂਡ ਵਿੱਚ ਜਾਣ ਉੱਤੇ ਰੁਕ ਜਾਂਦਾ ਹੈ। ਬਲੂਟੁੱਥ ਚੱਲਦਾ ਰਹਿੰਦਾ ਹੈ।",
   "settings.network.wifi_pair": "ਜੋੜਾ ਬਣਾਉਣਾ",
   "settings.network.wifi_paired": "ਜੋੜੇ ਗਏ ਡਿਵਾਈਸ",
   "settings.network.wifi_pair_find": "ਡਿਵਾਈਸ ਲੱਭੋ",

--- a/src/i18n/locales/pl.ts
+++ b/src/i18n/locales/pl.ts
@@ -1585,10 +1585,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "Transporty",
+  "settings.group.internet": "Internet",
   "settings.group.nearby": "W pobliżu",
   "settings.group.sync": "Synchronizacja",
   "settings.group.features": "Funkcje",
   "settings.group.messages": "Wiadomości",
+  "settings.group.local": "Lokalnie",
   "settings.group.media": "Multimedia",
   "settings.group.reset": "Reset",
   "settings.group.always_on": "Zawsze włączone",
@@ -1753,6 +1755,17 @@ export const strings: Strings = {
     "Ten przekaźnik już jest na twojej liście.",
   "settings.network.relay_invalid":
     "Podaj prawidłowy adres przekaźnika, np. relay.example.com. Port jest potrzebny tylko wtedy, gdy przekaźnik nie używa domyślnego. Adresy IP i nazwy lokalne są niedozwolone.",
+  "settings.network.lan": "Sieć lokalna",
+  "settings.network.lan_desc":
+    "Docieraj do osób w tej samej sieci WiFi, także między iPhone'em a Androidem. Inne urządzenia w sieci widzą, że używasz Airhop.",
+  "settings.network.lan_searching": "Brak urządzeń Airhop w tej sieci",
+  "settings.network.lan_active": "Połączono w tej sieci",
+  "settings.network.lan_unavailable": "Brak połączenia z siecią WiFi",
+  "settings.network.lan_permission":
+    "Dostęp do sieci lokalnej jest wyłączony dla Airhop",
+  "settings.network.lan_unsupported": "Niedostępne na tym urządzeniu",
+  "settings.network.lan_foreground":
+    "Zatrzymuje się, gdy Airhop działa w tle. Bluetooth działa dalej.",
   "settings.network.wifi_pair": "Parowanie",
   "settings.network.wifi_paired": "Sparowane urządzenia",
   "settings.network.wifi_pair_find": "Znajdź urządzenie",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1589,10 +1589,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "Transportes",
+  "settings.group.internet": "Internet",
   "settings.group.nearby": "Por perto",
   "settings.group.sync": "Sincronização",
   "settings.group.features": "Recursos",
   "settings.group.messages": "Mensagens",
+  "settings.group.local": "Local",
   "settings.group.media": "Mídia",
   "settings.group.reset": "Redefinição",
   "settings.group.always_on": "Sempre ligado",
@@ -1757,6 +1759,17 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "Esse relay já está na sua lista.",
   "settings.network.relay_invalid":
     "Digite um host de relay válido, por exemplo relay.example.com. A porta só é necessária se o relay não usar a padrão. Endereços IP e nomes locais não são aceitos.",
+  "settings.network.lan": "Rede local",
+  "settings.network.lan_desc":
+    "Alcance quem está no mesmo WiFi, inclusive entre iPhone e Android. Outros aparelhos na rede podem ver que você usa o Airhop.",
+  "settings.network.lan_searching": "Nenhum aparelho Airhop nesta rede",
+  "settings.network.lan_active": "Conectado nesta rede",
+  "settings.network.lan_unavailable": "Você não está em uma rede WiFi",
+  "settings.network.lan_permission":
+    "O acesso à rede local está desligado para o Airhop",
+  "settings.network.lan_unsupported": "Não disponível neste aparelho",
+  "settings.network.lan_foreground":
+    "Pausa quando o Airhop fica em segundo plano. O Bluetooth continua.",
   "settings.network.wifi_pair": "Pareamento",
   "settings.network.wifi_paired": "Dispositivos pareados",
   "settings.network.wifi_pair_find": "Encontrar um dispositivo",

--- a/src/i18n/locales/pt-PT.ts
+++ b/src/i18n/locales/pt-PT.ts
@@ -1593,10 +1593,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "Transportes",
+  "settings.group.internet": "Internet",
   "settings.group.nearby": "Por perto",
   "settings.group.sync": "Sincronização",
   "settings.group.features": "Funcionalidades",
   "settings.group.messages": "Mensagens",
+  "settings.group.local": "Local",
   "settings.group.media": "Multimédia",
   "settings.group.reset": "Reposição",
   "settings.group.always_on": "Sempre ligado",
@@ -1764,6 +1766,17 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "Esse relay já está na tua lista.",
   "settings.network.relay_invalid":
     "Escreve um anfitrião de relay válido, por exemplo relay.example.com. Só é preciso uma porta se o relay não usar a predefinida. Não são permitidos endereços IP nem nomes locais.",
+  "settings.network.lan": "Rede local",
+  "settings.network.lan_desc":
+    "Alcance quem está na mesma WiFi, incluindo entre iPhone e Android. Outros dispositivos na rede podem ver que está a usar o Airhop.",
+  "settings.network.lan_searching": "Nenhum dispositivo Airhop nesta rede",
+  "settings.network.lan_active": "Ligado nesta rede",
+  "settings.network.lan_unavailable": "Não está numa rede WiFi",
+  "settings.network.lan_permission":
+    "O acesso à rede local está desligado para o Airhop",
+  "settings.network.lan_unsupported": "Não disponível neste dispositivo",
+  "settings.network.lan_foreground":
+    "Pausa quando o Airhop está em segundo plano. O Bluetooth continua.",
   "settings.network.wifi_pair": "Emparelhamento",
   "settings.network.wifi_paired": "Dispositivos emparelhados",
   "settings.network.wifi_pair_find": "Encontrar um dispositivo",

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -1580,10 +1580,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "Транспорты",
+  "settings.group.internet": "Интернет",
   "settings.group.nearby": "Поблизости",
   "settings.group.sync": "Синхронизация",
   "settings.group.features": "Функции",
   "settings.group.messages": "Сообщения",
+  "settings.group.local": "Локально",
   "settings.group.media": "Медиа",
   "settings.group.reset": "Сброс",
   "settings.group.always_on": "Всегда включено",
@@ -1751,6 +1753,17 @@ export const strings: Strings = {
     "Этот ретранслятор уже есть в вашем списке.",
   "settings.network.relay_invalid":
     "Введите корректный хост ретранслятора, например relay.example.com. Порт нужен, только если ретранслятор не использует стандартный. IP-адреса и локальные имена не допускаются.",
+  "settings.network.lan": "Локальная сеть",
+  "settings.network.lan_desc":
+    "Связывайтесь с теми, кто в той же сети WiFi, в том числе между iPhone и Android. Другие устройства в сети видят, что вы используете Airhop.",
+  "settings.network.lan_searching": "В этой сети нет устройств Airhop",
+  "settings.network.lan_active": "Подключено в этой сети",
+  "settings.network.lan_unavailable": "Вы не в сети WiFi",
+  "settings.network.lan_permission":
+    "Доступ к локальной сети для Airhop выключен",
+  "settings.network.lan_unsupported": "Недоступно на этом устройстве",
+  "settings.network.lan_foreground":
+    "Останавливается, когда Airhop уходит в фон. Bluetooth продолжает работать.",
   "settings.network.wifi_pair": "Сопряжение",
   "settings.network.wifi_paired": "Связанные устройства",
   "settings.network.wifi_pair_find": "Найти устройство",

--- a/src/i18n/locales/sv.ts
+++ b/src/i18n/locales/sv.ts
@@ -1562,10 +1562,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "Transporter",
+  "settings.group.internet": "Internet",
   "settings.group.nearby": "I närheten",
   "settings.group.sync": "Synk",
   "settings.group.features": "Funktioner",
   "settings.group.messages": "Meddelanden",
+  "settings.group.local": "Lokalt",
   "settings.group.media": "Media",
   "settings.group.reset": "Återställning",
   "settings.group.always_on": "Alltid på",
@@ -1727,6 +1729,17 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "Det reläet finns redan i din lista.",
   "settings.network.relay_invalid":
     "Ange en giltig relävärd, t.ex. relay.example.com. En port behövs bara om reläet inte använder standardporten. IP-adresser och lokala namn är inte tillåtna.",
+  "settings.network.lan": "Lokalt nätverk",
+  "settings.network.lan_desc":
+    "Nå personer på samma WiFi, även mellan iPhone och Android. Andra enheter i nätverket kan se att du kör Airhop.",
+  "settings.network.lan_searching": "Inga Airhop-enheter i det här nätverket",
+  "settings.network.lan_active": "Ansluten i det här nätverket",
+  "settings.network.lan_unavailable": "Inte på ett WiFi-nätverk",
+  "settings.network.lan_permission":
+    "Åtkomst till lokalt nätverk är avstängd för Airhop",
+  "settings.network.lan_unsupported": "Inte tillgängligt på den här enheten",
+  "settings.network.lan_foreground":
+    "Pausar när Airhop är i bakgrunden. Bluetooth fortsätter.",
   "settings.network.wifi_pair": "Parkoppling",
   "settings.network.wifi_paired": "Parkopplade enheter",
   "settings.network.wifi_pair_find": "Hitta en enhet",

--- a/src/i18n/locales/sw.ts
+++ b/src/i18n/locales/sw.ts
@@ -1591,10 +1591,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "Wasafirishaji",
+  "settings.group.internet": "Intaneti",
   "settings.group.nearby": "Karibu",
   "settings.group.sync": "Usawazishaji",
   "settings.group.features": "Vipengele",
   "settings.group.messages": "Jumbe",
+  "settings.group.local": "Ndani",
   "settings.group.media": "Midia",
   "settings.group.reset": "Weka upya",
   "settings.group.always_on": "Daima imewashwa",
@@ -1761,6 +1763,18 @@ export const strings: Strings = {
     "Relay hiyo tayari iko kwenye orodha yako.",
   "settings.network.relay_invalid":
     "Weka mwenyeji halali wa relay, mfano relay.example.com. Mlango unahitajika tu ikiwa relay haitumii ule wa kawaida. Anwani za IP na majina ya ndani hayaruhusiwi.",
+  "settings.network.lan": "Mtandao wa ndani",
+  "settings.network.lan_desc":
+    "Fikia watu walio kwenye WiFi ile ile, hata kati ya iPhone na Android. Vifaa vingine kwenye mtandao vinaweza kuona kuwa unatumia Airhop.",
+  "settings.network.lan_searching":
+    "Hakuna vifaa vya Airhop kwenye mtandao huu",
+  "settings.network.lan_active": "Imeunganishwa kwenye mtandao huu",
+  "settings.network.lan_unavailable": "Hauko kwenye mtandao wa WiFi",
+  "settings.network.lan_permission":
+    "Ufikiaji wa mtandao wa ndani umezimwa kwa Airhop",
+  "settings.network.lan_unsupported": "Haipatikani kwenye kifaa hiki",
+  "settings.network.lan_foreground":
+    "Husimama Airhop inapokuwa nyuma. Bluetooth inaendelea.",
   "settings.network.wifi_pair": "Uoanishaji",
   "settings.network.wifi_paired": "Vifaa vilivyooanishwa",
   "settings.network.wifi_pair_find": "Tafuta kifaa",

--- a/src/i18n/locales/ta.ts
+++ b/src/i18n/locales/ta.ts
@@ -1613,10 +1613,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "கடத்திகள்",
+  "settings.group.internet": "இணையம்",
   "settings.group.nearby": "அருகில்",
   "settings.group.sync": "ஒத்திசைவு",
   "settings.group.features": "அம்சங்கள்",
   "settings.group.messages": "செய்திகள்",
+  "settings.group.local": "உள்ளூர்",
   "settings.group.media": "ஊடகம்",
   "settings.group.reset": "மீட்டமைப்பு",
   "settings.group.always_on": "எப்போதும் இயக்கத்தில்",
@@ -1785,6 +1787,18 @@ export const strings: Strings = {
     "அந்த ரிலே ஏற்கெனவே உங்கள் பட்டியலில் உள்ளது.",
   "settings.network.relay_invalid":
     "சரியான ரிலே புரவலனை உள்ளிடுங்கள், எடுத்துக்காட்டாக relay.example.com. ரிலே இயல்பு துறையைப் பயன்படுத்தாதபோது மட்டுமே துறை தேவை. IP முகவரிகளும் உள்ளூர்ப் பெயர்களும் அனுமதிக்கப்படவில்லை.",
+  "settings.network.lan": "உள்ளூர் நெட்வொர்க்",
+  "settings.network.lan_desc":
+    "அதே WiFi-ல் உள்ளவர்களை அடையுங்கள், iPhone மற்றும் Android இடையேயும். நெட்வொர்க்கில் உள்ள மற்ற சாதனங்கள் நீங்கள் Airhop பயன்படுத்துவதைக் காண முடியும்.",
+  "settings.network.lan_searching":
+    "இந்த நெட்வொர்க்கில் Airhop சாதனங்கள் இல்லை",
+  "settings.network.lan_active": "இந்த நெட்வொர்க்கில் இணைக்கப்பட்டுள்ளது",
+  "settings.network.lan_unavailable": "எந்த WiFi நெட்வொர்க்கிலும் இல்லை",
+  "settings.network.lan_permission":
+    "Airhop-க்கான உள்ளூர் நெட்வொர்க் அணுகல் அணைக்கப்பட்டுள்ளது",
+  "settings.network.lan_unsupported": "இந்த சாதனத்தில் கிடைக்கவில்லை",
+  "settings.network.lan_foreground":
+    "Airhop பின்னணிக்குச் சென்றால் நிற்கும். புளூடூத் தொடர்ந்து இயங்கும்.",
   "settings.network.wifi_pair": "இணைத்தல்",
   "settings.network.wifi_paired": "இணைக்கப்பட்ட சாதனங்கள்",
   "settings.network.wifi_pair_find": "ஒரு சாதனத்தைத் தேடு",

--- a/src/i18n/locales/th.ts
+++ b/src/i18n/locales/th.ts
@@ -1526,10 +1526,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "ช่องทางรับส่ง",
+  "settings.group.internet": "อินเทอร์เน็ต",
   "settings.group.nearby": "ใกล้เคียง",
   "settings.group.sync": "ซิงค์",
   "settings.group.features": "ฟีเจอร์",
   "settings.group.messages": "ข้อความ",
+  "settings.group.local": "ภายใน",
   "settings.group.media": "สื่อ",
   "settings.group.reset": "รีเซ็ต",
   "settings.group.always_on": "เปิดอยู่เสมอ",
@@ -1689,6 +1691,17 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "รีเลย์นั้นอยู่ในรายการของคุณแล้ว",
   "settings.network.relay_invalid":
     "ใส่โฮสต์รีเลย์ที่ถูกต้อง เช่น relay.example.com พอร์ตจำเป็นเมื่อรีเลย์ไม่ได้ใช้ค่าเริ่มต้นเท่านั้น ไม่อนุญาตให้ใช้ที่อยู่ IP และชื่อภายในเครือข่าย",
+  "settings.network.lan": "เครือข่ายภายใน",
+  "settings.network.lan_desc":
+    "ติดต่อผู้คนบน WiFi เดียวกัน รวมถึงระหว่าง iPhone กับ Android อุปกรณ์อื่นบนเครือข่ายจะเห็นว่าคุณกำลังใช้ Airhop",
+  "settings.network.lan_searching": "ไม่มีอุปกรณ์ Airhop บนเครือข่ายนี้",
+  "settings.network.lan_active": "เชื่อมต่อบนเครือข่ายนี้",
+  "settings.network.lan_unavailable": "ไม่ได้อยู่บนเครือข่าย WiFi",
+  "settings.network.lan_permission":
+    "การเข้าถึงเครือข่ายภายในถูกปิดสำหรับ Airhop",
+  "settings.network.lan_unsupported": "ใช้ไม่ได้บนอุปกรณ์นี้",
+  "settings.network.lan_foreground":
+    "หยุดเมื่อ Airhop อยู่เบื้องหลัง บลูทูธยังทำงานต่อ",
   "settings.network.wifi_pair": "การจับคู่",
   "settings.network.wifi_paired": "อุปกรณ์ที่จับคู่แล้ว",
   "settings.network.wifi_pair_find": "ค้นหาอุปกรณ์",

--- a/src/i18n/locales/tr.ts
+++ b/src/i18n/locales/tr.ts
@@ -1570,10 +1570,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "Taşıyıcılar",
+  "settings.group.internet": "İnternet",
   "settings.group.nearby": "Yakında",
   "settings.group.sync": "Eşitleme",
   "settings.group.features": "Özellikler",
   "settings.group.messages": "Mesajlar",
+  "settings.group.local": "Yerel",
   "settings.group.media": "Medya",
   "settings.group.reset": "Sıfırlama",
   "settings.group.always_on": "Her zaman açık",
@@ -1734,6 +1736,16 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "O aktarıcı zaten listende.",
   "settings.network.relay_invalid":
     "Geçerli bir aktarıcı adresi gir, örneğin relay.example.com. Bağlantı noktası yalnızca aktarıcı varsayılanı kullanmıyorsa gerekir. IP adresleri ve yerel adlar kabul edilmez.",
+  "settings.network.lan": "Yerel ağ",
+  "settings.network.lan_desc":
+    "Aynı WiFi'deki kişilere ulaşın, iPhone ile Android arasında da. Ağdaki diğer cihazlar Airhop kullandığınızı görebilir.",
+  "settings.network.lan_searching": "Bu ağda Airhop cihazı yok",
+  "settings.network.lan_active": "Bu ağda bağlı",
+  "settings.network.lan_unavailable": "Bir WiFi ağında değilsiniz",
+  "settings.network.lan_permission": "Airhop için yerel ağ erişimi kapalı",
+  "settings.network.lan_unsupported": "Bu cihazda kullanılamıyor",
+  "settings.network.lan_foreground":
+    "Airhop arka plana geçtiğinde durur. Bluetooth çalışmaya devam eder.",
   "settings.network.wifi_pair": "Eşleştirme",
   "settings.network.wifi_paired": "Eşleştirilmiş cihazlar",
   "settings.network.wifi_pair_find": "Cihaz bul",

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -1575,10 +1575,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "Транспорти",
+  "settings.group.internet": "Інтернет",
   "settings.group.nearby": "Поблизу",
   "settings.group.sync": "Синхронізація",
   "settings.group.features": "Функції",
   "settings.group.messages": "Повідомлення",
+  "settings.group.local": "Локально",
   "settings.group.media": "Медіа",
   "settings.group.reset": "Скидання",
   "settings.group.always_on": "Завжди увімкнено",
@@ -1740,6 +1742,17 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "Цей релей уже є у вашому списку.",
   "settings.network.relay_invalid":
     "Введіть дійсний хост релея, наприклад relay.example.com. Порт потрібен, лише якщо релей не використовує типовий. IP-адреси та локальні імена не дозволені.",
+  "settings.network.lan": "Локальна мережа",
+  "settings.network.lan_desc":
+    "Зв’язуйтеся з людьми в тій самій мережі WiFi, зокрема між iPhone і Android. Інші пристрої в мережі бачать, що ви користуєтеся Airhop.",
+  "settings.network.lan_searching": "У цій мережі немає пристроїв Airhop",
+  "settings.network.lan_active": "Підключено в цій мережі",
+  "settings.network.lan_unavailable": "Ви не в мережі WiFi",
+  "settings.network.lan_permission":
+    "Доступ до локальної мережі для Airhop вимкнено",
+  "settings.network.lan_unsupported": "Недоступно на цьому пристрої",
+  "settings.network.lan_foreground":
+    "Зупиняється, коли Airhop у фоні. Bluetooth продовжує працювати.",
   "settings.network.wifi_pair": "Спарювання",
   "settings.network.wifi_paired": "З’єднані пристрої",
   "settings.network.wifi_pair_find": "Знайти пристрій",

--- a/src/i18n/locales/ur.ts
+++ b/src/i18n/locales/ur.ts
@@ -1554,10 +1554,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "ذرائع",
+  "settings.group.internet": "انٹرنیٹ",
   "settings.group.nearby": "قریب",
   "settings.group.sync": "ہم وقت سازی",
   "settings.group.features": "خصوصیات",
   "settings.group.messages": "پیغامات",
+  "settings.group.local": "مقامی",
   "settings.group.media": "میڈیا",
   "settings.group.reset": "دوبارہ ترتیب",
   "settings.group.always_on": "ہمیشہ چالو",
@@ -1718,6 +1720,17 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "وہ ریلے پہلے ہی آپ کی فہرست میں ہے۔",
   "settings.network.relay_invalid":
     "درست ریلے میزبان درج کریں، مثلاً relay.example.com۔ پورٹ صرف تب چاہیے جب ریلے طے شدہ پورٹ استعمال نہ کرتا ہو۔ IP پتے اور مقامی نام قابل قبول نہیں۔",
+  "settings.network.lan": "مقامی نیٹ ورک",
+  "settings.network.lan_desc":
+    "اسی WiFi پر موجود لوگوں تک پہنچیں، iPhone اور Android کے درمیان بھی۔ نیٹ ورک پر موجود دوسرے آلات دیکھ سکتے ہیں کہ آپ Airhop چلا رہے ہیں۔",
+  "settings.network.lan_searching": "اس نیٹ ورک پر کوئی Airhop آلہ نہیں",
+  "settings.network.lan_active": "اس نیٹ ورک پر منسلک",
+  "settings.network.lan_unavailable": "کسی WiFi نیٹ ورک پر نہیں",
+  "settings.network.lan_permission":
+    "Airhop کے لیے مقامی نیٹ ورک تک رسائی بند ہے",
+  "settings.network.lan_unsupported": "اس آلے پر دستیاب نہیں",
+  "settings.network.lan_foreground":
+    "Airhop کے پس منظر میں جانے پر رک جاتا ہے۔ بلوٹوتھ چلتا رہتا ہے۔",
   "settings.network.wifi_pair": "جوڑا بنانا",
   "settings.network.wifi_paired": "جوڑے گئے آلات",
   "settings.network.wifi_pair_find": "آلہ تلاش کریں",

--- a/src/i18n/locales/vi.ts
+++ b/src/i18n/locales/vi.ts
@@ -1568,10 +1568,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "Kênh truyền",
+  "settings.group.internet": "Internet",
   "settings.group.nearby": "Ở gần",
   "settings.group.sync": "Đồng bộ",
   "settings.group.features": "Tính năng",
   "settings.group.messages": "Tin nhắn",
+  "settings.group.local": "Nội bộ",
   "settings.group.media": "Phương tiện",
   "settings.group.reset": "Đặt lại",
   "settings.group.always_on": "Luôn bật",
@@ -1737,6 +1739,18 @@ export const strings: Strings = {
     "Bộ chuyển tiếp đó đã có trong danh sách của bạn.",
   "settings.network.relay_invalid":
     "Hãy nhập một máy chủ chuyển tiếp hợp lệ, ví dụ relay.example.com. Chỉ cần ghi cổng nếu bộ chuyển tiếp không dùng cổng mặc định. Không cho phép địa chỉ IP và tên cục bộ.",
+  "settings.network.lan": "Mạng nội bộ",
+  "settings.network.lan_desc":
+    "Kết nối với những người trên cùng WiFi, kể cả giữa iPhone và Android. Các thiết bị khác trên mạng có thể thấy bạn đang chạy Airhop.",
+  "settings.network.lan_searching":
+    "Không có thiết bị Airhop nào trên mạng này",
+  "settings.network.lan_active": "Đã kết nối trên mạng này",
+  "settings.network.lan_unavailable": "Không ở trên mạng WiFi nào",
+  "settings.network.lan_permission":
+    "Quyền truy cập mạng nội bộ đang tắt cho Airhop",
+  "settings.network.lan_unsupported": "Không khả dụng trên thiết bị này",
+  "settings.network.lan_foreground":
+    "Tạm dừng khi Airhop chạy nền. Bluetooth vẫn tiếp tục.",
   "settings.network.wifi_pair": "Ghép đôi",
   "settings.network.wifi_paired": "Thiết bị đã ghép đôi",
   "settings.network.wifi_pair_find": "Tìm một thiết bị",

--- a/src/i18n/locales/zh-Hans.ts
+++ b/src/i18n/locales/zh-Hans.ts
@@ -1466,10 +1466,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "传输方式",
+  "settings.group.internet": "互联网",
   "settings.group.nearby": "附近",
   "settings.group.sync": "同步",
   "settings.group.features": "功能",
   "settings.group.messages": "消息",
+  "settings.group.local": "本地",
   "settings.group.media": "媒体",
   "settings.group.reset": "重置",
   "settings.group.always_on": "始终开启",
@@ -1621,6 +1623,16 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "那个中继已经在你的列表里了。",
   "settings.network.relay_invalid":
     "请输入有效的中继主机名，例如 relay.example.com。只有当中继不使用默认端口时才需要写端口。不允许使用 IP 地址和本地名称。",
+  "settings.network.lan": "本地网络",
+  "settings.network.lan_desc":
+    "联系同一 WiFi 上的人，iPhone 和 Android 之间也可以。网络上的其他设备能看到你在运行 Airhop。",
+  "settings.network.lan_searching": "此网络上没有 Airhop 设备",
+  "settings.network.lan_active": "已在此网络上连接",
+  "settings.network.lan_unavailable": "未连接 WiFi 网络",
+  "settings.network.lan_permission": "Airhop 的本地网络访问已关闭",
+  "settings.network.lan_unsupported": "此设备不支持",
+  "settings.network.lan_foreground":
+    "Airhop 进入后台时会暂停。蓝牙会继续运行。",
   "settings.network.wifi_pair": "配对",
   "settings.network.wifi_paired": "已配对的设备",
   "settings.network.wifi_pair_find": "查找设备",

--- a/src/i18n/locales/zh-Hant.ts
+++ b/src/i18n/locales/zh-Hant.ts
@@ -1468,10 +1468,12 @@ export const strings: Strings = {
 
   // ---- Settings: group headings ----
   "settings.group.transports": "傳輸方式",
+  "settings.group.internet": "網際網路",
   "settings.group.nearby": "附近",
   "settings.group.sync": "同步",
   "settings.group.features": "功能",
   "settings.group.messages": "訊息",
+  "settings.group.local": "本機",
   "settings.group.media": "媒體",
   "settings.group.reset": "重設",
   "settings.group.always_on": "永遠開啟",
@@ -1624,6 +1626,16 @@ export const strings: Strings = {
   "settings.network.relay_duplicate": "那個中繼已經在你的清單裡了。",
   "settings.network.relay_invalid":
     "請輸入有效的中繼主機名稱，例如 relay.example.com。只有當中繼不用預設連接埠時才需要寫連接埠。不允許使用 IP 位址和本機名稱。",
+  "settings.network.lan": "本機網路",
+  "settings.network.lan_desc":
+    "聯繫同一 WiFi 上的人，iPhone 與 Android 之間也可以。網路上的其他裝置能看到你正在執行 Airhop。",
+  "settings.network.lan_searching": "此網路上沒有 Airhop 裝置",
+  "settings.network.lan_active": "已在此網路上連線",
+  "settings.network.lan_unavailable": "未連上 WiFi 網路",
+  "settings.network.lan_permission": "Airhop 的本機網路存取已關閉",
+  "settings.network.lan_unsupported": "此裝置不支援",
+  "settings.network.lan_foreground":
+    "Airhop 進入背景時會暫停。藍牙會繼續運作。",
   "settings.network.wifi_pair": "配對",
   "settings.network.wifi_paired": "已配對的裝置",
   "settings.network.wifi_pair_find": "尋找裝置",

--- a/src/services/__tests__/file-transfer-service.test.ts
+++ b/src/services/__tests__/file-transfer-service.test.ts
@@ -39,10 +39,17 @@ const META = {
 // The transport now answers whether it ACCEPTED the packet, and the pacer waits
 // for that answer before offering the next fragment. `accepted` lets a test play
 // a radio that is refusing writes, which is the case that used to lose files.
-function makeService(accepted = true) {
+function makeService(accepted = true, usesBleRadio?: () => boolean) {
   const broadcast = jest.fn().mockResolvedValue(accepted);
   const unicast = jest.fn().mockResolvedValue(accepted);
-  const service = new FileTransferService(IDENTITY, broadcast, unicast);
+  const service = new FileTransferService(
+    IDENTITY,
+    broadcast,
+    unicast,
+    undefined,
+    undefined,
+    usesBleRadio,
+  );
   return { service, broadcast, unicast };
 }
 
@@ -78,6 +85,84 @@ describe("outbound pacing", () => {
     for (let i = 0; i < f.length; i++) f[i] = (i * 167 + 13) & 0xff;
     return f;
   })();
+
+  // Fragment spacing exists for the Bluetooth radio, which drops writes handed
+  // over faster than it can make them. A link that is not a radio needs no gap,
+  // and pacing one anyway was the whole reason the WiFi fast path moved a file
+  // no faster than Bluetooth did.
+  // A second transfer starting while the first is mid-write used to open a
+  // parallel drain loop: `drainTimer` is cleared before the transport is
+  // awaited, so nothing stopped a fresh timer being set in that window. Two
+  // loops on one queue hand the radio fragments at twice the spacing, which is
+  // exactly the loss the spacing prevents.
+  it("does not open a second drain while one is with the transport", async () => {
+    // Collected in an array rather than a single binding: TypeScript cannot see
+    // that a promise executor runs synchronously, so a plain `let` narrows to
+    // never at the call below.
+    const pending: ((accepted: boolean) => void)[] = [];
+    const unicast = jest.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          pending.push(resolve);
+        }),
+    );
+    const broadcast = jest.fn().mockResolvedValue(true);
+    const service = new FileTransferService(IDENTITY, broadcast, unicast);
+
+    service.sendBytes(FILE, META, "dm:1111222233334444");
+    await tick();
+    expect(unicast).toHaveBeenCalledTimes(1);
+
+    // A second transfer arrives while the first fragment is still in flight.
+    service.sendBytes(FILE, META, "dm:5555666677778888");
+    await tick(3);
+
+    // Still exactly one write outstanding: the queue grew, the loop did not.
+    expect(unicast).toHaveBeenCalledTimes(1);
+
+    // And the queue resumes once the transport answers, so nothing stalls.
+    pending[0](true);
+    await tick(2);
+    expect(unicast.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  describe("pacing by transport", () => {
+    it("waits the Bluetooth gap when the path is Bluetooth", async () => {
+      const { service, unicast } = makeService(true, () => true);
+
+      service.sendBytes(FILE, META, "dm:1111222233334444");
+
+      await tick(1, 24);
+      expect(unicast).not.toHaveBeenCalled();
+
+      await tick(1, 1);
+      expect(unicast).toHaveBeenCalledTimes(1);
+    });
+
+    it("waits no gap when nothing on the path is Bluetooth", async () => {
+      const { service, unicast } = makeService(true, () => false);
+
+      service.sendBytes(FILE, META, "dm:1111222233334444");
+
+      await tick(1, 0);
+      expect(unicast).toHaveBeenCalledTimes(1);
+
+      await tick(1, 0);
+      expect(unicast).toHaveBeenCalledTimes(2);
+    });
+
+    it("stays on the Bluetooth gap when the caller does not say", async () => {
+      const { service, unicast } = makeService();
+
+      service.sendBytes(FILE, META, "dm:1111222233334444");
+
+      await tick(1, 24);
+      expect(unicast).not.toHaveBeenCalled();
+
+      await tick(1, 1);
+      expect(unicast).toHaveBeenCalledTimes(1);
+    });
+  });
 
   it("does not dispatch the whole file synchronously", () => {
     const { service, broadcast } = makeService();

--- a/src/services/__tests__/lan-controller.test.ts
+++ b/src/services/__tests__/lan-controller.test.ts
@@ -1,0 +1,364 @@
+/**
+ * @jest-environment node
+ */
+// The LAN transport differs from the other two in a way worth pinning down: it
+// does not run because the mesh is running, it runs because somebody asked for
+// it. Publishing an mDNS record tells everyone on the network, and whoever runs
+// the network, that this phone is carrying Airhop, so consent is a precondition
+// rather than a preference.
+//
+// The properties that matter:
+//   * Nothing is published until the user turns it on AND the mesh is up.
+//   * Turning it off stops publishing, not just dialling.
+//   * Who gets dialled is the ring's answer, capped, and never dialled twice.
+//   * A device that cannot run it is asked once, not polled forever.
+
+const mockStartLAN = jest.fn<Promise<void>, [string]>();
+const mockStopLAN = jest.fn<Promise<void>, []>();
+const mockConnectToPeer = jest.fn<Promise<void>, [string]>();
+
+jest.mock("@bridge/NativeAirhopLAN", () => ({
+  __esModule: true,
+  default: {
+    startLAN: (name: string) => mockStartLAN(name),
+    stopLAN: () => mockStopLAN(),
+    connectToPeer: (name: string) => mockConnectToPeer(name),
+    writeToLANLink: () => Promise.resolve(),
+    addListener: () => undefined,
+    removeListeners: () => undefined,
+  },
+}));
+
+import { LANController } from "../lan-controller";
+
+const SELF = "5000000000000000";
+
+function rejectWith(code: string): Promise<never> {
+  const error = new Error(code) as Error & { code: string };
+  error.code = code;
+  return Promise.reject(error);
+}
+
+// Let every pending microtask and every expired timer run, repeatedly, so a
+// retry that schedules another retry is followed to its conclusion.
+async function settle(ms = 0): Promise<void> {
+  for (let i = 0; i < 8; i++) {
+    jest.advanceTimersByTime(ms);
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+}
+
+// Long enough to clear the discovery settle window.
+const SETTLED = 600;
+
+function running(): LANController {
+  const lan = new LANController(() => SELF);
+  lan.start();
+  lan.setEnabled(true);
+  return lan;
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  mockStartLAN.mockReset();
+  mockStartLAN.mockResolvedValue(undefined);
+  mockStopLAN.mockReset();
+  mockStopLAN.mockResolvedValue(undefined);
+  mockConnectToPeer.mockReset();
+  mockConnectToPeer.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("consent", () => {
+  test("publishes nothing until the user turns it on", async () => {
+    const lan = new LANController(() => SELF);
+
+    lan.start();
+    await settle();
+
+    expect(mockStartLAN).not.toHaveBeenCalled();
+    expect(lan.isStarted).toBe(false);
+  });
+
+  test("publishes nothing while it is on but the mesh is not running", async () => {
+    const lan = new LANController(() => SELF);
+
+    lan.setEnabled(true);
+    await settle();
+
+    expect(mockStartLAN).not.toHaveBeenCalled();
+  });
+
+  test("publishes once both are true, under the name it was given", async () => {
+    const lan = running();
+    await settle();
+
+    expect(mockStartLAN).toHaveBeenCalledWith(SELF);
+    expect(lan.isStarted).toBe(true);
+  });
+
+  test("turning it off stops publishing, not just dialling", async () => {
+    const lan = running();
+    await settle();
+
+    lan.setEnabled(false);
+    await settle();
+
+    expect(mockStopLAN).toHaveBeenCalled();
+    expect(lan.isStarted).toBe(false);
+  });
+
+  test("going Away stops it even while the switch is still on", async () => {
+    const lan = running();
+    await settle();
+
+    lan.stop();
+    await settle();
+
+    expect(lan.isStarted).toBe(false);
+  });
+});
+
+// The privacy policy claims records from two networks cannot be matched to the
+// same phone. That is only true while the published name changes, so it is
+// pinned here rather than left to the comment.
+describe("the published name", () => {
+  test("is minted fresh for every publishing session", async () => {
+    let n = 0;
+    const lan = new LANController(() => `name-${String(++n)}`);
+
+    lan.start();
+    lan.setEnabled(true);
+    await settle();
+    expect(mockStartLAN).toHaveBeenLastCalledWith("name-1");
+
+    // Walking out of the office and into a cafe: the transport comes down and
+    // goes back up.
+    lan.setEnabled(false);
+    await settle();
+    lan.setEnabled(true);
+    await settle();
+
+    expect(mockStartLAN).toHaveBeenLastCalledWith("name-2");
+  });
+
+  test("forgets peers found under the previous name", async () => {
+    let n = 0;
+    const lan = new LANController(() => `name-${String(++n)}`);
+    lan.start();
+    lan.setEnabled(true);
+    await settle();
+
+    lan.onPeerDiscovered("9000000000000000");
+    expect(lan.discoveredCount).toBe(1);
+
+    lan.setEnabled(false);
+    await settle();
+    lan.setEnabled(true);
+    await settle();
+
+    // A peer seen on the old network is not a peer on this one.
+    expect(lan.discoveredCount).toBe(0);
+  });
+});
+
+describe("dialling", () => {
+  function discover(lan: LANController, names: readonly string[]): void {
+    for (const serviceName of names) lan.onPeerDiscovered(serviceName);
+  }
+
+  test("dials nobody before the discovery burst settles", async () => {
+    const lan = running();
+    await settle();
+
+    discover(lan, ["6000000000000000"]);
+    await settle();
+
+    expect(mockConnectToPeer).not.toHaveBeenCalled();
+  });
+
+  test("dials the peers the ring says are ours to open", async () => {
+    const lan = running();
+    await settle();
+
+    // One below us and one above. Only the one above is ours to dial.
+    discover(lan, ["1000000000000000", "9000000000000000"]);
+    await settle(SETTLED);
+
+    expect(mockConnectToPeer).toHaveBeenCalledTimes(1);
+    expect(mockConnectToPeer).toHaveBeenCalledWith("9000000000000000");
+  });
+
+  test("never dials the same peer twice", async () => {
+    const lan = running();
+    await settle();
+
+    discover(lan, ["9000000000000000"]);
+    await settle(SETTLED);
+    discover(lan, ["9000000000000000"]);
+    await settle(SETTLED);
+
+    expect(mockConnectToPeer).toHaveBeenCalledTimes(1);
+  });
+
+  test("dials a peer again after a refused connect", async () => {
+    mockConnectToPeer.mockRejectedValue(new Error("CONNECT_FAILED"));
+    const lan = running();
+    await settle();
+
+    discover(lan, ["9000000000000000"]);
+    await settle(SETTLED);
+    expect(mockConnectToPeer).toHaveBeenCalledTimes(1);
+
+    lan.onPeerLost("9000000000000000");
+    discover(lan, ["9000000000000000"]);
+    await settle(SETTLED);
+
+    expect(mockConnectToPeer).toHaveBeenCalledTimes(2);
+  });
+
+  // A TCP link can drop while the peer's mDNS record stays perfectly visible.
+  // Nothing about that is a discovery change, so without the periodic pass the
+  // peer would be lost until it restarted.
+  test("walks the plan again on a timer, so a dropped link is reopened", async () => {
+    const lan = running();
+    await settle();
+
+    discover(lan, ["9000000000000000"]);
+    await settle(SETTLED);
+    expect(mockConnectToPeer).toHaveBeenCalledTimes(1);
+
+    // No discovery change at all: just time passing.
+    await settle(16_000);
+
+    expect(mockConnectToPeer.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  test("stops reviewing once the transport is off", async () => {
+    const lan = running();
+    await settle();
+    discover(lan, ["9000000000000000"]);
+    await settle(SETTLED);
+    const dialled = mockConnectToPeer.mock.calls.length;
+
+    lan.setEnabled(false);
+    await settle(60_000);
+
+    expect(mockConnectToPeer.mock.calls.length).toBe(dialled);
+  });
+
+  test("ignores our own record coming back off the network", async () => {
+    const lan = running();
+    await settle();
+
+    discover(lan, [SELF]);
+    await settle(SETTLED);
+
+    expect(mockConnectToPeer).not.toHaveBeenCalled();
+    expect(lan.discoveredCount).toBe(0);
+  });
+
+  test("does not dial while the transport is not running", async () => {
+    const lan = new LANController(() => SELF);
+    lan.start();
+
+    discover(lan, ["9000000000000000"]);
+    await settle(SETTLED);
+
+    expect(mockConnectToPeer).not.toHaveBeenCalled();
+  });
+});
+
+describe("failures", () => {
+  test("asks once on a device that will never support it", async () => {
+    mockStartLAN.mockImplementation(() => rejectWith("LAN_UNSUPPORTED"));
+    const lan = running();
+
+    await settle(60_000);
+
+    expect(mockStartLAN).toHaveBeenCalledTimes(1);
+    expect(lan.isUnsupported).toBe(true);
+  });
+
+  test("keeps trying while the network is merely missing", async () => {
+    mockStartLAN.mockImplementation(() => rejectWith("LAN_UNAVAILABLE"));
+    const lan = running();
+
+    await settle(10_000);
+
+    expect(mockStartLAN.mock.calls.length).toBeGreaterThan(1);
+    expect(lan.isUnsupported).toBe(false);
+  });
+
+  test("keeps trying after a refused permission, since it can be granted", async () => {
+    mockStartLAN.mockImplementation(() => rejectWith("PERMISSION_DENIED"));
+    const lan = running();
+
+    await settle(10_000);
+
+    expect(mockStartLAN.mock.calls.length).toBeGreaterThan(1);
+    expect(lan.failure).toBe("permission");
+  });
+
+  test("recovers when the network goes away and comes back", async () => {
+    const lan = running();
+    await settle();
+    expect(lan.isStarted).toBe(true);
+
+    lan.onAvailabilityChanged(false);
+    await settle();
+    expect(lan.isStarted).toBe(false);
+
+    lan.onAvailabilityChanged(true);
+    await settle();
+    expect(lan.isStarted).toBe(true);
+  });
+
+  test("forgets the network it was on when that network goes away", async () => {
+    const lan = running();
+    await settle();
+    lan.onPeerDiscovered("9000000000000000");
+    expect(lan.discoveredCount).toBe(1);
+
+    lan.onAvailabilityChanged(false);
+
+    expect(lan.discoveredCount).toBe(0);
+  });
+});
+
+describe("reported state", () => {
+  test("says searching while running with nobody found", async () => {
+    const seen: string[] = [];
+    const lan = new LANController(
+      () => SELF,
+      (s) => seen.push(s),
+    );
+
+    lan.start();
+    lan.setEnabled(true);
+    await settle();
+
+    expect(seen).toContain("searching");
+  });
+
+  test("says active once a link is up, and searching again when it drops", async () => {
+    const seen: string[] = [];
+    const lan = new LANController(
+      () => SELF,
+      (s) => seen.push(s),
+    );
+    lan.start();
+    lan.setEnabled(true);
+    await settle();
+
+    lan.setLinkCount(1);
+    expect(seen).toContain("active");
+
+    lan.setLinkCount(0);
+    expect(seen[seen.length - 1]).toBe("searching");
+  });
+});

--- a/src/services/__tests__/lan-dial-policy.test.ts
+++ b/src/services/__tests__/lan-dial-policy.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @jest-environment node
+ */
+// The rule that stops mDNS turning a room into a full mesh.
+//
+// The properties asserted below are what the rest of the mesh depends on, so
+// they are checked over a whole simulated room rather than one device: every
+// pair agrees, nobody dials twice, the graph stays connected, and no device
+// carries more links than the cap allows.
+import { dialTargets, MAX_LAN_LINKS } from "../lan-dial-policy";
+
+// Peer IDs are 16 lowercase hex characters, all the same length, so a plain
+// string sort is the numeric one.
+function room(count: number): string[] {
+  return Array.from({ length: count }, (_, i) =>
+    i.toString(16).padStart(16, "0"),
+  );
+}
+
+// Every link the room ends up holding, from each device's own decision.
+function linksOf(peers: readonly string[]): Map<string, Set<string>> {
+  const links = new Map<string, Set<string>>(
+    peers.map((p) => [p, new Set<string>()]),
+  );
+  for (const self of peers) {
+    const others = peers.filter((p) => p !== self);
+    for (const target of dialTargets(self, others)) {
+      links.get(self)?.add(target);
+      links.get(target)?.add(self);
+    }
+  }
+  return links;
+}
+
+function isConnected(links: Map<string, Set<string>>): boolean {
+  const all = [...links.keys()];
+  if (all.length === 0) return true;
+  const seen = new Set<string>([all[0]]);
+  const queue = [all[0]];
+  while (queue.length > 0) {
+    const next = queue.shift() as string;
+    for (const peer of links.get(next) ?? []) {
+      if (seen.has(peer)) continue;
+      seen.add(peer);
+      queue.push(peer);
+    }
+  }
+  return seen.size === all.length;
+}
+
+describe("dialTargets", () => {
+  it("dials nobody when the network is empty", () => {
+    expect(dialTargets("aaaa", [])).toEqual([]);
+  });
+
+  it("has exactly one side of a pair dial", () => {
+    expect(dialTargets("aaaa", ["bbbb"])).toEqual(["bbbb"]);
+    expect(dialTargets("bbbb", ["aaaa"])).toEqual([]);
+  });
+
+  it("ignores our own ID appearing in the discovered list", () => {
+    expect(dialTargets("aaaa", ["aaaa", "bbbb"])).toEqual(["bbbb"]);
+  });
+
+  it("connects everyone to everyone while the room is under the cap", () => {
+    const peers = room(4);
+    const links = linksOf(peers);
+
+    for (const peer of peers) {
+      expect(links.get(peer)?.size).toBe(peers.length - 1);
+    }
+  });
+
+  describe("a room past the cap", () => {
+    const peers = room(30);
+    const links = linksOf(peers);
+
+    it("holds no device over the cap", () => {
+      for (const peer of peers) {
+        expect(links.get(peer)?.size).toBeLessThanOrEqual(MAX_LAN_LINKS);
+      }
+    });
+
+    it("spreads the load rather than pointing the room at a few phones", () => {
+      const counts = peers.map((p) => links.get(p)?.size ?? 0);
+      expect(Math.min(...counts)).toBe(MAX_LAN_LINKS);
+      expect(Math.max(...counts)).toBe(MAX_LAN_LINKS);
+    });
+
+    it("leaves the graph connected, so nothing is stranded", () => {
+      expect(isConnected(links)).toBe(true);
+    });
+
+    it("never has both ends dial the same pair", () => {
+      for (const self of peers) {
+        const others = peers.filter((p) => p !== self);
+        for (const target of dialTargets(self, others)) {
+          const back = dialTargets(
+            target,
+            peers.filter((p) => p !== target),
+          );
+          expect(back).not.toContain(self);
+        }
+      }
+    });
+  });
+
+  it("stays connected at the sizes a venue actually reaches", () => {
+    for (const size of [2, 3, 5, 9, 16, 50, 200]) {
+      const peers = room(size);
+      const links = linksOf(peers);
+      expect(isConnected(links)).toBe(true);
+      for (const peer of peers) {
+        expect(links.get(peer)?.size).toBeLessThanOrEqual(MAX_LAN_LINKS);
+      }
+    }
+  });
+
+  it("is stable: the same room always produces the same plan", () => {
+    const peers = room(12);
+    const shuffled = [...peers].reverse();
+    expect(
+      dialTargets(
+        peers[3],
+        peers.filter((p) => p !== peers[3]),
+      ),
+    ).toEqual(
+      dialTargets(
+        peers[3],
+        shuffled.filter((p) => p !== peers[3]),
+      ),
+    );
+  });
+});

--- a/src/services/file-transfer-service.ts
+++ b/src/services/file-transfer-service.ts
@@ -70,6 +70,18 @@ import * as FileSystem from "expo-file-system";
 const FRAGMENT_SPACING_DIRECTED_MS = 25;
 const FRAGMENT_SPACING_MS = 30;
 
+// Spacing when nothing on the path touches the Bluetooth radio.
+//
+// The gap above is a Bluetooth requirement, not a protocol one: the stack drops
+// fragments handed over faster than it can write them. A socket has flow
+// control of its own and needs no help, so the only reason to keep a timer at
+// all is to yield between fragments and leave the UI responsive.
+//
+// Fragment SIZE does not change with it. The receiver reassembles by index, the
+// next hop may be Bluetooth, and bitchat refuses an over-size frame as it
+// decodes, so 467 bytes is protocol and stays whatever carries it.
+const FAST_LINK_SPACING_MS = 0;
+
 // How long to wait after the radio REFUSES a fragment before offering it again.
 //
 // The spacing above assumes the link can always take the next write, and one-way
@@ -371,6 +383,15 @@ export type SealFileFn = (
   fileTlv: Uint8Array,
 ) => Packet | null;
 
+// Whether a fragment for this recipient will put bytes on the Bluetooth radio,
+// which is the only thing fragment spacing exists for. A channel fragment goes
+// down every link at once, so it is Bluetooth as soon as one Bluetooth link is
+// held.
+export type UsesBleRadioFn = (
+  recipientPeerID: string,
+  isDM: boolean,
+) => boolean;
+
 // NOTE: naming lives in wireFileName(), which owns the extension and bitchat's
 // stable-ID shape together. Nothing here may put localized UI copy on the wire:
 // a display word is not a file name, and one without an extension arrives as a
@@ -440,10 +461,13 @@ export class FileTransferService {
     weight?: number;
   }[] = [];
   private drainTimer: ReturnType<typeof setTimeout> | null = null;
+  // Whether a fragment is with the transport right now. See drainOne.
+  private draining = false;
   // Monotonic, so back-to-back sends cannot collide on a transfer id.
   private transferSeq = 0;
 
   private readonly sealFile?: SealFileFn;
+  private readonly usesBleRadio?: UsesBleRadioFn;
 
   // Throttles the "that attachment didn't arrive" line, per sender.
   private readonly failureNotifier = new AttachmentFailureNotifier();
@@ -454,12 +478,14 @@ export class FileTransferService {
     unicast: PacedUnicastFn,
     resolveNickname?: (peerID: string) => string | undefined,
     sealFile?: SealFileFn,
+    usesBleRadio?: UsesBleRadioFn,
   ) {
     this.identity = identity;
     this.broadcast = broadcast;
     this.unicast = unicast;
     this.resolveNickname = resolveNickname;
     this.sealFile = sealFile;
+    this.usesBleRadio = usesBleRadio;
   }
 
   // Receive a fully reassembled FILE_TRANSFER packet from the fragment layer.
@@ -640,16 +666,30 @@ export class FileTransferService {
     weight?: number,
   ): void {
     this.outQueue.push({ pkt, isDM, recipientPeerID, transferId, weight });
-    this.scheduleDrain();
+    // Paced from the first fragment, not just between them. Scheduling this one
+    // on the Bluetooth gap and the rest on the real one costs a transfer its
+    // whole head start on a link that never needed the gap.
+    this.scheduleDrain(this.spacingFor(isDM, recipientPeerID));
   }
 
-  // Spacing owed after handing over a fragment, by how many links it cost.
-  private static spacingFor(isDM: boolean): number {
+  // Spacing owed after handing over a fragment.
+  //
+  // Bluetooth decides it: if any link on the path is a radio, the whole
+  // transfer is paced for the radio, since the queue that overflows is shared.
+  // Only when nothing on the path is Bluetooth can the gap go.
+  //
+  // Absent the caller's answer this stays on the Bluetooth timings. A transfer
+  // that is slower than it needed to be is a nuisance; one paced faster than
+  // the radio can take drops fragments and never completes.
+  private spacingFor(isDM: boolean, recipientPeerID: string): number {
+    if (this.usesBleRadio?.(recipientPeerID, isDM) === false) {
+      return FAST_LINK_SPACING_MS;
+    }
     return isDM ? FRAGMENT_SPACING_DIRECTED_MS : FRAGMENT_SPACING_MS;
   }
 
-  private scheduleDrain(delayMs: number = FRAGMENT_SPACING_DIRECTED_MS): void {
-    if (this.drainTimer !== null) return;
+  private scheduleDrain(delayMs: number): void {
+    if (this.draining || this.drainTimer !== null) return;
     this.drainTimer = setTimeout(() => {
       this.drainTimer = null;
       void this.drainOne();
@@ -670,6 +710,18 @@ export class FileTransferService {
     if (next === undefined) return;
 
     let accepted = false;
+    // Held across the await, and only the await.
+    //
+    // `drainTimer` is cleared before this runs, so without a second flag an
+    // enqueue landing while the transport is still answering starts a parallel
+    // drain: two loops shifting one queue, handing the radio fragments twice as
+    // fast as the spacing allows. That is the packet loss the spacing exists to
+    // prevent, and a second transfer beginning during a first is ordinary.
+    //
+    // Released before the tail re-schedules below, which is safe because
+    // everything after the await is synchronous and nothing can interleave with
+    // it. Releasing later would swallow that schedule and stall the queue.
+    this.draining = true;
     try {
       accepted = next.isDM
         ? await this.unicast(next.recipientPeerID, next.pkt)
@@ -677,6 +729,8 @@ export class FileTransferService {
     } catch {
       // A transport that threw is a transport that did not take it.
       accepted = false;
+    } finally {
+      this.draining = false;
     }
 
     const tx =
@@ -707,7 +761,7 @@ export class FileTransferService {
     if (this.outQueue.length > 0) {
       this.scheduleDrain(
         accepted
-          ? FileTransferService.spacingFor(next.isDM)
+          ? this.spacingFor(next.isDM, next.recipientPeerID)
           : REFUSED_BACKOFF_MS,
       );
     }

--- a/src/services/lan-controller.ts
+++ b/src/services/lan-controller.ts
@@ -1,0 +1,413 @@
+// The one place that decides whether the LAN transport should be running, and
+// makes reality match.
+//
+// Same reconciler as wifi-controller.ts, and for the same reasons: a DESIRED
+// state, an OBSERVED outcome, one idempotent pass that closes the gap, and a
+// retry when it cannot. Read that file for why one fire-and-forget start call
+// is not enough.
+//
+// Two things differ from the other transports.
+//
+// Consent. This does not run because the mesh is running; it runs when the user
+// turns it on. An mDNS record is cleartext to the whole network and is logged by
+// ordinary infrastructure, which on a workplace or venue network is an
+// attendance list, so `setEnabled` gates everything and defaults to off.
+//
+// Dialling. mDNS returns the whole network, so who to connect to is a decision
+// rather than a consequence. lan-dial-policy.ts makes it; native opens the
+// sockets it is told to.
+
+import NativeAirhopLAN from "@bridge/NativeAirhopLAN";
+import type { LanState } from "@store/mesh-state-store";
+import { dialTargets } from "./lan-dial-policy";
+
+// Retry schedule for a start that was refused. Matches the WiFi ladder: nothing
+// the user is looking at depends on this transport, so being a few seconds late
+// costs nothing and polling a network interface in a pocket is not free.
+const BACKOFF_MS = [500, 1500, 4000, 10_000, 30_000] as const;
+
+// How long to wait after a discovery before dialling.
+//
+// mDNS answers arrive in a burst, one per device. Dialling on the first means
+// planning a ring of two, then replanning as each further answer lands.
+// Settling first costs half a second nobody is watching and produces one
+// correct plan instead of N wrong ones.
+const DISCOVERY_SETTLE_MS = 500;
+
+// How often to walk the dial plan again while the transport is running.
+//
+// A TCP link can drop while the peer's mDNS record stays visible, which is no
+// discovery change at all, so without this a hiccup loses that peer until it
+// restarts. Matched to the gossip sync interval. Re-dialling a live peer is
+// free: `connectToPeer` is idempotent, and which names are linked stays with
+// native.
+const DIAL_REVIEW_MS = 15_000;
+
+// Rejection codes the native modules use. A union rather than message text:
+// wording is a UI concern and control flow that reads it breaks the first time
+// somebody rewords it.
+type LanFailure =
+  // No mDNS stack, or an OS below the floor. Permanent.
+  | "unsupported"
+  // No network, or not on WiFi. Clears on its own.
+  | "unavailable"
+  // Local network access refused. Android asks at runtime; on iOS the prompt is
+  // raised by browsing and a refusal is only reversible in Settings.
+  | "permission"
+  // Anything else. Treated as transient, having nothing better to assume.
+  | "transient";
+
+function classify(error: unknown): LanFailure {
+  const code = (error as { code?: string } | undefined)?.code;
+  switch (code) {
+    case "LAN_UNSUPPORTED":
+      return "unsupported";
+    case "LAN_UNAVAILABLE":
+      return "unavailable";
+    case "PERMISSION_DENIED":
+      return "permission";
+    default:
+      return "transient";
+  }
+}
+
+// A name to publish on the network, good for one publishing session.
+//
+// Never the peer ID, which is derived from the long-term Noise key and never
+// changes: publishing it in a record every network logs would let anyone
+// holding logs from two networks link them. Sixteen random hex characters carry
+// no history and collide rarely enough that mDNS never renames us.
+//
+// Called for every start, not once per process. A phone carried from an office
+// to a cafe stops and starts on the way, and one name across both would hand an
+// observer the link this denies.
+export function newInstanceName(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(8));
+  let hex = "";
+  for (const b of bytes) hex += b.toString(16).padStart(2, "0");
+  return hex;
+}
+
+export class LANController {
+  // A factory rather than a name: one is minted per publishing session, so the
+  // same phone on two networks is two unrelated records. See newInstanceName.
+  constructor(
+    private readonly makeInstanceName: () => string,
+    private readonly onState?: (state: LanState) => void,
+  ) {}
+
+  // What we are currently published as, and what the ring sorts on. Empty until
+  // the first start.
+  private instanceName = "";
+
+  private reported: LanState = "off";
+
+  private report(state: LanState): void {
+    if (state === this.reported) return;
+    this.reported = state;
+    this.onState?.(state);
+  }
+
+  // The user's switch. Everything else is downstream of this.
+  private enabled = false;
+  // Whether the mesh as a whole is running. Both must be true.
+  private meshRunning = false;
+  private started = false;
+  private unsupported = false;
+  private lastFailure: LanFailure | null = null;
+
+  // Everyone mDNS currently sees, by the name they publish. A name is the only
+  // address this layer needs: the ring sorts on it and native dials by it.
+  private readonly discovered = new Set<string>();
+  // Dials currently in flight, so a pass that lands while one is open does not
+  // start a second. Emptied when each settles, either way: a name that stays
+  // here after its dial finished is a peer that can never be dialled again.
+  private readonly dialling = new Set<string>();
+
+  private linkCount = 0;
+
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
+  private settleTimer: ReturnType<typeof setTimeout> | null = null;
+  private reviewTimer: ReturnType<typeof setInterval> | null = null;
+  private attempt = 0;
+  private reconciling = false;
+  private dirty = false;
+  private disposed = false;
+  // Bumped whenever intent changes under an in-flight start, so a resolve that
+  // lands late cannot mark the transport started against an intent that has
+  // already moved on. Same guard, and the same reason, as the WiFi controller.
+  private generation = 0;
+
+  setEnabled(enabled: boolean): void {
+    if (this.enabled === enabled) return;
+    this.enabled = enabled;
+    if (!enabled) this.generation += 1;
+    this.attempt = 0;
+    void this.reconcile();
+  }
+
+  start(): void {
+    this.meshRunning = true;
+    this.attempt = 0;
+    void this.reconcile();
+  }
+
+  stop(): void {
+    this.meshRunning = false;
+    this.generation += 1;
+    this.clearTimers();
+    void this.reconcile();
+  }
+
+  // The world may have moved: the app was resumed, a permission was granted,
+  // the phone joined a different network.
+  refresh(): void {
+    if (this.unsupported) return;
+    this.attempt = 0;
+    void this.reconcile();
+  }
+
+  // Native saw the network go away or come back.
+  //
+  // Losing it is the case that is otherwise unrecoverable: the listener and the
+  // browser are dead but the module still holds its handles, so every later
+  // start resolves instantly having done nothing. Forgetting that belief here
+  // is what lets the next pass do real work.
+  onAvailabilityChanged(available: boolean): void {
+    if (this.unsupported) return;
+    if (!available) {
+      this.started = false;
+      this.generation += 1;
+      this.forgetNetwork();
+      void NativeAirhopLAN?.stopLAN().catch(() => {});
+      this.attempt = 0;
+      this.scheduleRetry();
+      return;
+    }
+    this.attempt = 0;
+    void this.reconcile();
+  }
+
+  // How many LAN links the registry holds. The controller owns what the Mesh
+  // tab says, and this is the one input it cannot observe: links are reported
+  // to mesh-service, not here. Same shape as WiFiController.setPairedCount.
+  //
+  // "searching" rather than "nothing here" while the count is zero: client
+  // isolation is on by default at most venues and cannot be detected before
+  // trying, so an empty network and a network that forbids peer traffic look
+  // identical from inside the app.
+  setLinkCount(count: number): void {
+    if (this.linkCount === count) return;
+    this.linkCount = count;
+    if (this.started && this.wanted) {
+      this.report(count > 0 ? "active" : "searching");
+    }
+  }
+
+  onPeerDiscovered(serviceName: string): void {
+    if (serviceName === this.instanceName) return;
+    if (this.discovered.has(serviceName)) return;
+    this.discovered.add(serviceName);
+    this.scheduleSettle();
+  }
+
+  onPeerLost(serviceName: string): void {
+    this.discovered.delete(serviceName);
+    this.dialling.delete(serviceName);
+    this.scheduleSettle();
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.generation += 1;
+    this.clearTimers();
+    this.enabled = false;
+    this.meshRunning = false;
+    if (this.started) void this.releaseNative();
+  }
+
+  private clearTimers(): void {
+    if (this.retryTimer !== null) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
+    if (this.settleTimer !== null) {
+      clearTimeout(this.settleTimer);
+      this.settleTimer = null;
+    }
+    if (this.reviewTimer !== null) {
+      clearInterval(this.reviewTimer);
+      this.reviewTimer = null;
+    }
+  }
+
+  private forgetNetwork(): void {
+    this.discovered.clear();
+    this.dialling.clear();
+    this.linkCount = 0;
+  }
+
+  private scheduleRetry(): void {
+    if (this.disposed || !this.wanted) return;
+    if (this.retryTimer !== null) return;
+    const delay = BACKOFF_MS[Math.min(this.attempt, BACKOFF_MS.length - 1)];
+    this.attempt++;
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null;
+      void this.reconcile();
+    }, delay);
+  }
+
+  private scheduleSettle(): void {
+    if (this.disposed || this.settleTimer !== null) return;
+    this.settleTimer = setTimeout(() => {
+      this.settleTimer = null;
+      this.dialPlanned();
+    }, DISCOVERY_SETTLE_MS);
+  }
+
+  private get wanted(): boolean {
+    return this.enabled && this.meshRunning;
+  }
+
+  // Open the links the ring says are ours to open.
+  //
+  // Runs on every arrival and departure, and again on a timer, so a link that
+  // dropped while its peer stayed visible is reopened. Native is idempotent, so
+  // a peer already linked costs one resolved call.
+  private dialPlanned(): void {
+    if (!this.started || !this.wanted) return;
+    const targets = dialTargets(this.instanceName, [...this.discovered]);
+    for (const name of targets) {
+      if (this.dialling.has(name)) continue;
+      this.dialling.add(name);
+      const settle = (): void => {
+        this.dialling.delete(name);
+      };
+      NativeAirhopLAN?.connectToPeer(name).then(settle, () => {
+        // A refused connect is usually client isolation, which never clears,
+        // but it can also be a peer that has not finished opening its listener.
+        // Either way the next review asks again; the cost of asking is one
+        // rejected promise.
+        settle();
+      });
+    }
+  }
+
+  private scheduleReview(): void {
+    if (this.disposed || this.reviewTimer !== null) return;
+    this.reviewTimer = setInterval(() => {
+      this.dialPlanned();
+    }, DIAL_REVIEW_MS);
+  }
+
+  private async reconcile(): Promise<void> {
+    if (this.disposed) return;
+    if (this.reconciling) {
+      this.dirty = true;
+      return;
+    }
+    this.reconciling = true;
+    try {
+      do {
+        this.dirty = false;
+        await this.reconcileOnce();
+      } while (this.dirty && !this.disposed);
+    } finally {
+      this.reconciling = false;
+    }
+  }
+
+  private async reconcileOnce(): Promise<void> {
+    const generation = this.generation;
+
+    // No module at all: a build without the native side. Latched, so a device
+    // with no LAN transport is asked once and never polled again.
+    if (NativeAirhopLAN === null || NativeAirhopLAN === undefined) {
+      this.unsupported = true;
+      this.report("unsupported");
+      return;
+    }
+
+    if (!this.wanted) {
+      if (this.started) await this.releaseNative();
+      this.report("off");
+      return;
+    }
+
+    if (this.unsupported) return;
+    if (this.started) return;
+
+    // A fresh name for this session. Anything discovered under the old one is
+    // stale by definition: we were not on this network when it was published.
+    this.instanceName = this.makeInstanceName();
+    this.forgetNetwork();
+
+    try {
+      await NativeAirhopLAN.startLAN(this.instanceName);
+    } catch (error) {
+      const failure = classify(error);
+      this.lastFailure = failure;
+      if (failure === "unsupported") {
+        this.unsupported = true;
+        this.report("unsupported");
+        return;
+      }
+      this.report(failure === "permission" ? "permission" : "unavailable");
+      this.scheduleRetry();
+      return;
+    }
+
+    // Intent moved while the start was in flight, so this result is stale.
+    if (generation !== this.generation) {
+      await this.releaseNative();
+      return;
+    }
+
+    this.started = true;
+    this.lastFailure = null;
+    this.attempt = 0;
+    this.report(this.linkCount > 0 ? "active" : "searching");
+
+    // `stop()` and `dispose()` are synchronous and can land while the start
+    // above is in flight. Release here rather than deferring to the loop, which
+    // does not run again once disposed.
+    if (!this.wanted || this.disposed) {
+      await this.releaseNative();
+      return;
+    }
+
+    // Anything discovered while starting still needs dialling, and from here on
+    // the plan is walked again periodically.
+    this.scheduleSettle();
+    this.scheduleReview();
+  }
+
+  private async releaseNative(): Promise<void> {
+    this.started = false;
+    this.forgetNetwork();
+    try {
+      await NativeAirhopLAN?.stopLAN();
+    } catch {
+      // Best effort. The sockets go with the process either way, and a refused
+      // stop must not leave `started` claiming a live transport.
+    }
+  }
+
+  get isStarted(): boolean {
+    return this.started;
+  }
+
+  get isUnsupported(): boolean {
+    return this.unsupported;
+  }
+
+  get failure(): LanFailure | null {
+    return this.lastFailure;
+  }
+
+  // Peers currently visible on the network, for the Mesh tab's neutral note.
+  get discoveredCount(): number {
+    return this.discovered.size;
+  }
+}

--- a/src/services/lan-dial-policy.ts
+++ b/src/services/lan-dial-policy.ts
@@ -1,0 +1,55 @@
+// Who to open a LAN link to, out of everyone mDNS found.
+//
+// Bluetooth caps itself: the radio holds six or so links and refuses more. mDNS
+// hands back every device on the network, so the cap has to be deliberate here,
+// or the mesh lands in a density none of its constants were tuned for. See
+// ARCHITECTURE.md section 3 for the arithmetic.
+//
+// Policy, so it is a pure function here rather than a decision in native. Same
+// split as power-policy.ts.
+
+// Links one phone opens on a network.
+//
+// Sized against Bluetooth rather than the network: bitchat caps central links at
+// 6 (`bleMaxCentralLinks`), so eight keeps a LAN room reading the way a
+// Bluetooth room does to the flood router's jitter bands and TTL cap.
+//
+// Even, because the ring below takes half on each side.
+export const MAX_LAN_LINKS = 8;
+
+// The peers this device should dial.
+//
+// Names, not peer IDs. The ring needs an identifier every device agrees on for
+// the session, and LAN's is the random mDNS instance name (see
+// lan-controller.ts). Anything durable published here would be linkable across
+// networks.
+//
+// Sort every name, our own included, into one ring; link to the
+// `MAX_LAN_LINKS / 2` peers either side. Both ends compute the same ring from
+// the same list, so they agree without negotiating, and each dials only the
+// pairs sorting after its own name so nobody dials a peer already dialling
+// them.
+//
+// A ring rather than "everyone dials the lowest N", which would point the room
+// at a few phones: a star with hot spots, not a mesh. Below the cap the ring
+// wraps and every peer is a neighbour, which is right for a hotspot.
+export function dialTargets(
+  selfName: string,
+  discovered: readonly string[],
+  maxLinks: number = MAX_LAN_LINKS,
+): readonly string[] {
+  const ring = [...new Set([selfName, ...discovered])].sort();
+  const size = ring.length;
+  if (size < 2 || maxLinks < 1) return [];
+
+  const selfIndex = ring.indexOf(selfName);
+  const reach = Math.max(1, Math.floor(maxLinks / 2));
+  const neighbours = new Set<string>();
+  for (let offset = 1; offset <= reach; offset++) {
+    neighbours.add(ring[(selfIndex + offset) % size]);
+    neighbours.add(ring[(((selfIndex - offset) % size) + size) % size]);
+  }
+  neighbours.delete(selfName);
+
+  return [...neighbours].filter((name) => name > selfName).sort();
+}

--- a/src/services/mesh-service.ts
+++ b/src/services/mesh-service.ts
@@ -691,6 +691,18 @@ export class MeshService {
       (peerID) => this.registry.get(peerID)?.nickname,
       (recipientPeerID, fileTlv) =>
         this.sealFileForPeer(recipientPeerID, fileTlv),
+      // Whether this transfer has to be paced for the Bluetooth radio.
+      //
+      // A DM rides one link, so the answer is that link's transport. A channel
+      // fragment goes down every link at once, so it is Bluetooth the moment we
+      // hold one Bluetooth link. Unknown recipient answers Bluetooth: a
+      // transfer paced slower than it needed to be is a nuisance, one paced
+      // faster than the radio can take never completes.
+      (recipientPeerID, isDM) => {
+        if (!isDM) return this.links.size("ble") > 0;
+        const link = this.links.linkFor(recipientPeerID);
+        return link === undefined || link.kind === "ble";
+      },
     );
 
     const nostrSendFn: NostrSendFn = async (

--- a/src/services/mesh-service.ts
+++ b/src/services/mesh-service.ts
@@ -384,8 +384,10 @@ export class MeshService {
   // A remote peer's Nostr pubkey hex to their peerID, filled as ANNOUNCEs arrive.
   private readonly nostrPubkeyToPeerID = new Map<string, string>();
 
-  // Relay jitter adapts to how many peers we can hear, over every radio.
-  private readonly floodRouter = new FloodRouter(() => this.links.size());
+  // Relay jitter and the time-critical TTL cap adapt to how crowded the
+  // Bluetooth mesh is. See LinkRegistry.degree for why that is peers rather
+  // than links, and Bluetooth rather than every transport.
+  private readonly floodRouter = new FloodRouter(() => this.links.degree());
   private readonly registry = new PeerRegistry();
   private readonly announceManager = new AnnounceManager();
   private readonly router: MessageRouter;

--- a/src/services/mesh-service.ts
+++ b/src/services/mesh-service.ts
@@ -14,6 +14,7 @@
 //   - Expose sendChannelMessage(), sendDm(), sendAttachment() for feature layer
 
 import AirhopBLE from "@bridge/NativeAirhopBLE";
+import NativeAirhopLAN from "@bridge/NativeAirhopLAN";
 import NativeAirhopWiFi from "@bridge/NativeAirhopWiFi";
 import {
   decodeContactCard,
@@ -52,7 +53,11 @@ import {
   decodeAnnouncePayload,
   isAnnounceFresh,
 } from "@core/mesh/discovery/announce-manager";
-import { LinkRegistry } from "@core/mesh/links/link-registry";
+import {
+  LinkRegistry,
+  TRANSPORT_KINDS,
+  type TransportKind,
+} from "@core/mesh/links/link-registry";
 import {
   openChannelMessage,
   sealChannelMessage,
@@ -218,6 +223,7 @@ import {
   isGeoChannel,
   type GeoParticipant,
 } from "./geohash-channel-service";
+import { LANController, newInstanceName } from "./lan-controller";
 import { rebindNutzapWatcher } from "./nutzap-watcher-handle";
 import { PrivateChannelService } from "./private-channel-service";
 import { RadioController } from "./radio-controller";
@@ -471,10 +477,12 @@ export class MeshService {
     ble: (linkID, dataBase64) => AirhopBLE.writeToLink(linkID, dataBase64),
     // A build with no WiFi module holds no WiFi links, so this is never
     // reached; it resolves rather than throwing so that stays true if one ever
-    // is opened before the module is checked.
+    // is opened before the module is checked. Same for LAN.
     wifi: (linkID, dataBase64) =>
       NativeAirhopWiFi?.writeToWiFiLink(linkID, dataBase64) ??
       Promise.resolve(),
+    lan: (linkID, dataBase64) =>
+      NativeAirhopLAN?.writeToLANLink(linkID, dataBase64) ?? Promise.resolve(),
   });
   // In-progress Noise XX handshakes keyed by remote peerID.
   private readonly pendingHandshakes = new Map<string, PendingHandshake>();
@@ -578,6 +586,15 @@ export class MeshService {
     useMeshStateStore.getState().setWifiFastPath(state),
   );
 
+  // Owns the LAN transport: whether it should be publishing, who to dial out of
+  // everyone mDNS found, and what the Mesh tab says about it.
+  //
+  // A fresh instance name per session, never the peer ID. See newInstanceName.
+  private readonly lan = new LANController(newInstanceName, (state) =>
+    useMeshStateStore.getState().setLanState(state),
+  );
+  private lanPrefUnsub: (() => void) | null = null;
+
   // Which devices the WiFi fast path is allowed to reach, iOS only.
   //
   // Apple's WiFi Aware has no unpaired mode, so a paired count of zero means the
@@ -605,11 +622,10 @@ export class MeshService {
   // announce to may be several hops away with no link of ours anywhere near it.
   // Reporting them separately is what makes "nobody is nearby" and "the radio is
   // not connecting" distinguishable in a bug report.
-  getLinkCounts(): { ble: number; wifi: number } {
-    return {
-      ble: this.links.size("ble"),
-      wifi: this.links.size("wifi"),
-    };
+  getLinkCounts(): Record<TransportKind, number> {
+    return Object.fromEntries(
+      TRANSPORT_KINDS.map((kind) => [kind, this.links.size(kind)]),
+    ) as Record<TransportKind, number>;
   }
 
   constructor(identity: Identity) {
@@ -668,8 +684,15 @@ export class MeshService {
       // only the addressee's handler claims it. File transfers are excluded:
       // they are far too large to flood and stay a direct-link feature. No-op
       // when we have no neighbour to relay through.
+      //
+      // Any neighbour, on any transport. This counted Bluetooth links alone,
+      // which was the same thing back when Bluetooth was the only one that
+      // relayed. It stopped being the same thing once a phone could hold LAN
+      // links and no Bluetooth at all: past the LAN cap not everyone is a
+      // direct neighbour, so a DM to someone a hop away had a relay available
+      // and was never handed to it.
       if (
-        this.links.size("ble") > 0 &&
+        this.links.size() > 0 &&
         packet.type !== PacketType.FILE_TRANSFER &&
         packet.type !== PacketType.FRAGMENT
       ) {
@@ -1160,6 +1183,71 @@ export class MeshService {
       ),
     );
 
+    this.subs.push(
+      DeviceEventEmitter.addListener(
+        "AirhopLAN.availabilityChanged",
+        ({ available }: { available: boolean }) => {
+          this.lan.onAvailabilityChanged(available);
+          if (!available) {
+            // The sockets went with the network. Forget them here rather than
+            // finding out one failed write at a time: the disconnect events
+            // cover an orderly close, not an interface disappearing.
+            this.links.closeAll("lan");
+            this.lan.setLinkCount(0);
+          }
+        },
+      ),
+      DeviceEventEmitter.addListener(
+        "AirhopLAN.peerDiscovered",
+        ({ serviceName }: { serviceName: string }) => {
+          this.lan.onPeerDiscovered(serviceName);
+        },
+      ),
+      DeviceEventEmitter.addListener(
+        "AirhopLAN.peerLost",
+        ({ serviceName }: { serviceName: string }) => {
+          this.lan.onPeerLost(serviceName);
+        },
+      ),
+      DeviceEventEmitter.addListener(
+        "AirhopLAN.linkConnected",
+        ({ linkID }: { linkID: string }) => {
+          this.links.open("lan", linkID);
+          this.lan.setLinkCount(this.links.size("lan"));
+          // A fresh announce, for the reason the WiFi link-up gives: the held
+          // greeting would be deduplicated as a copy of the one that went out
+          // over another transport, and it is the second announce that binds
+          // the peer to THIS link.
+          const pkt = this.announceManager.buildPacket(
+            this.identity,
+            this.nickname,
+            [],
+            hexToBytes(this.nostrPubKeyHex),
+            this.localCapabilities(),
+            this.bridgeService?.advertisedBridgeGeohash(),
+          );
+          this.links
+            .send(linkID, bytesToBase64(encodePacket(pkt)))
+            .catch(() => {});
+        },
+      ),
+      DeviceEventEmitter.addListener(
+        "AirhopLAN.linkDisconnected",
+        ({ linkID }: { linkID: string }) => {
+          // Bookkeeping only, as with WiFi: Bluetooth still carries the mesh,
+          // so a closing LAN link does not mean the peer has left.
+          this.links.close(linkID);
+          this.lan.setLinkCount(this.links.size("lan"));
+        },
+      ),
+      DeviceEventEmitter.addListener(
+        "AirhopLAN.packetReceived",
+        ({ linkID, dataBase64 }: { linkID: string; dataBase64: string }) => {
+          this.handleRaw(linkID, dataBase64);
+        },
+      ),
+    );
+
     // Start WiFi Aware (Android only) through its reconciler, for the same
     // reasons the radios go through theirs:
     // one attempt with its error discarded could not survive WiFi being off at
@@ -1178,6 +1266,17 @@ export class MeshService {
     // delivers the first.
     this.wifiPairing.start();
     this.wifi.start();
+
+    // The LAN transport runs only when the user has asked for it, so its
+    // switch is read here and watched below. Unlike the radios, a mesh that is
+    // running is not on its own a reason to publish anything.
+    this.lan.setEnabled(useSettingsStore.getState().lanTransportEnabled);
+    this.lan.start();
+    this.lanPrefUnsub?.();
+    this.lanPrefUnsub = useSettingsStore.subscribe((state, prev) => {
+      if (state.lanTransportEnabled === prev.lanTransportEnabled) return;
+      this.lan.setEnabled(state.lanTransportEnabled);
+    });
 
     // The radio controller reads the background preference during reconcile, so
     // the switch has to ask for one. Without this the foreground service would
@@ -5632,6 +5731,7 @@ export class MeshService {
     // diverge here, turning WiFi on and returning to the app fixes Bluetooth and
     // leaves the fast path dead until a relaunch.
     this.wifi.refresh();
+    this.lan.refresh();
     void this.wifiPairing.refresh();
   }
 
@@ -5668,6 +5768,7 @@ export class MeshService {
     usePeerStore.getState().evictStale();
     this.radio.refresh();
     this.wifi.refresh();
+    this.lan.refresh();
     // Pull-to-refresh is also the recovery path for a pairing removed in the
     // Settings app while Airhop was suspended, where the change event had no
     // running listener to reach.
@@ -6207,6 +6308,13 @@ export class MeshService {
     // service. Calling the native stops again here would race that.
     this.wifi.stop();
     this.wifiPairing.stop();
+    this.lan.stop();
+    this.lanPrefUnsub?.();
+    this.lanPrefUnsub = null;
+    // Same reason the WiFi links are cleared below: a LAN link is a socket that
+    // stopLAN() destroys, and the disconnect events cannot clean up because the
+    // subscriptions are already gone.
+    this.links.closeAll("lan");
     // And forget the links it just closed. Unlike a BLE central link, which
     // survives a stopped scan, a WiFi link is a socket stopWiFi() destroys, and
     // link IDs are never reissued. The native disconnect events cannot clean up
@@ -6256,6 +6364,10 @@ export class MeshService {
     // and reopen a socket under an identity that no longer exists.
     this.wifi.dispose();
     this.wifiPairing.stop();
+    // Same reason, and the stakes are higher here: a pending start that landed
+    // after a panic wipe would publish an mDNS record on the network under an
+    // identity that no longer exists.
+    this.lan.dispose();
   }
 }
 

--- a/src/services/panic-wipe.ts
+++ b/src/services/panic-wipe.ts
@@ -246,6 +246,10 @@ export async function panicWipe(): Promise<PanicWipeResult> {
     // too. Left set, a wipe on a phone with WiFi off would open the fresh
     // install on a note about a transport it has not tried yet.
     wifiFastPath: "unknown",
+    // Same rule for the LAN transport, which a wipe has just switched off along
+    // with every other setting. Left set, the Network screen would keep
+    // describing a network this phone is no longer publishing on.
+    lanState: "off",
     // Which cells we were listening in is a record of where the user was. It
     // goes with the mesh that was just destroyed, and null is the honest value
     // for a device that is no longer listening anywhere.

--- a/src/store/mesh-state-store.ts
+++ b/src/store/mesh-state-store.ts
@@ -76,6 +76,19 @@ export type WifiFastPath =
   | "unpaired"
   | "permission";
 
+// What the LAN transport is doing, for the Mesh tab and the Network screen.
+//
+// "off" is the resting state, not a failure: this transport does not run until
+// the user turns it on, because publishing an mDNS record tells everyone on the
+// network, and whoever runs it, that this phone is carrying Airhop.
+//
+// "searching" covers both an empty network and one whose access point forbids
+// peer traffic. Client isolation is on by default at most venues and cannot be
+// detected before trying, so the two are indistinguishable from inside the app
+// and the copy must not claim to know which it is.
+export type LanState =
+  "off" | "unsupported" | "unavailable" | "permission" | "searching" | "active";
+
 // The single reason the BLE mesh cannot run right now, or "none".
 //
 // One value rather than three independent booleans (adapterEnabled,
@@ -191,6 +204,8 @@ interface MeshStateStore {
   liveGeoCells: string[] | null;
   // State of the WiFi Aware fast path (see services/wifi-controller).
   wifiFastPath: WifiFastPath;
+  // State of the LAN transport (see services/lan-controller).
+  lanState: LanState;
   // Wi-Fi Aware pairing, iOS only (see services/wifi-pairing-service). Both stay
   // false and zero on Android, where the Network screen hides the section rather
   // than showing a control that would do nothing.
@@ -267,6 +282,7 @@ interface MeshStateStore {
   setWipeIncomplete: (incomplete: boolean) => void;
   setLiveGeoCells: (cells: string[] | null) => void;
   setWifiFastPath: (state: WifiFastPath) => void;
+  setLanState: (state: LanState) => void;
   setWifiPairing: (supported: boolean, count: number) => void;
   setNostrConnected: (connected: boolean) => void;
   setTorActive: (active: boolean) => void;
@@ -285,6 +301,7 @@ export const useMeshStateStore = create<MeshStateStore>()((set) => ({
   wipeIncomplete: false,
   liveGeoCells: null,
   wifiFastPath: "unknown",
+  lanState: "off",
   wifiPairingSupported: false,
   wifiPairedCount: 0,
   nostrConnected: false,
@@ -322,6 +339,9 @@ export const useMeshStateStore = create<MeshStateStore>()((set) => ({
   },
   setWifiFastPath(state) {
     set({ wifiFastPath: state });
+  },
+  setLanState(state) {
+    set({ lanState: state });
   },
   setWifiPairing(supported, count) {
     set({ wifiPairingSupported: supported, wifiPairedCount: count });

--- a/src/store/settings-store.ts
+++ b/src/store/settings-store.ts
@@ -85,6 +85,14 @@ interface SettingsState {
   // Distinct from Away, which stops the mesh even in the foreground. The middle
   // state: run while I am using it, stop when I am not.
   backgroundMeshEnabled: boolean;
+  // Whether to run the mesh over the WiFi network this phone is joined to.
+  //
+  // Off by default, and the only transport that is. Publishing an mDNS record
+  // broadcasts to every device on the network, and to whoever runs it, that
+  // this phone is carrying Airhop. On a venue, campus or corporate network that
+  // is logged by ordinary infrastructure with no app installed, so it is the
+  // user's call rather than ours.
+  lanTransportEnabled: boolean;
   // Whether a system notification withholds the sender and the message body.
   //
   // ON by default, which is the deliberate part. The lock screen is rendered by
@@ -171,6 +179,7 @@ interface SettingsState {
   setAutoDownloadMedia: (enabled: boolean) => void;
   setLiveVoiceEnabled: (enabled: boolean) => void;
   setBackgroundMeshEnabled: (enabled: boolean) => void;
+  setLanTransportEnabled: (enabled: boolean) => void;
   setHideNotificationPreviews: (hide: boolean) => void;
   setUploadQuality: (quality: UploadQuality) => void;
   setMediaRetentionDays: (days: MediaRetentionDays) => void;
@@ -202,6 +211,7 @@ const DEFAULTS = {
   autoDownloadMedia: true,
   liveVoiceEnabled: true,
   backgroundMeshEnabled: true,
+  lanTransportEnabled: false,
   // Private by default; see the field comment above for why.
   hideNotificationPreviews: true,
   uploadQuality: "high",
@@ -253,6 +263,9 @@ export const useSettingsStore = create<SettingsState>()(
       },
       setBackgroundMeshEnabled(enabled) {
         set({ backgroundMeshEnabled: enabled });
+      },
+      setLanTransportEnabled(enabled) {
+        set({ lanTransportEnabled: enabled });
       },
       setLiveVoiceEnabled(enabled) {
         set({ liveVoiceEnabled: enabled });


### PR DESCRIPTION
## Summary

Wi-Fi Aware cannot cross platforms: Apple requires a paired data path that Android cannot complete. So an iPhone and Android on the same Wi-Fi had no local route and fell back to Bluetooth or the internet. mDNS discovery over ordinary TCP closes that gap.

The links carry the same packet frames as Bluetooth, so the wire format stays unchanged, the mesh engine needs no new concept, and bitchat interop is untouched.

### What it adds

* Works **iPhone to Android**, the only non-Bluetooth path between them
* Needs **no internet**: a phone hotspot is enough
* A **1 MiB file moves in about a second** instead of 56
* **Off by default**, the only transport that is
* Carries the whole mesh: channels, DMs, attachments, ecash, voice, courier, multi-hop

## The cap, and why it exists

Bluetooth limits itself by physics: the radio holds about six links and refuses more. mDNS returns the whole network.

Thirty phones fully connected is **435 sockets**, and one broadcast costs **841 writes instead of 29** because every phone relays to everyone it holds and the deduplicator discards the copies. A channel photo turns that into millions of writes for one file. Bluetooth avoids this only because the radio refuses the links.

So LAN caps at **8**, sized against bitchat's `bleMaxCentralLinks` of 6:

* Every published name sorts into one ring; a device links to the four either side
* It dials only those sorting after its own, so no pair is dialled twice
* Both ends compute the same ring, so they agree without negotiating
* Below the cap the ring wraps and everyone is a neighbour, which is right for a hotspot

The rule is a pure function in `src/services/lan-dial-policy.ts`. Native reports what it sees and opens the sockets it is told to.

## Privacy considerations

* The mDNS record publishes a **random name, minted fresh per publishing session**, never the peer ID
* An mDNS record is cleartext on the network and logged by ordinary infrastructure, so a stable name would let anyone holding logs from two networks link them
* The ring sorts on that random name, so discovery needs no durable identifier
* Identity is proven in the ANNOUNCE, once the link is up
* Privacy policy updated in the app and on the site

## Two fixes this uncovered

Both are independent of LAN and land first, so they can be reviewed or reverted on their own.

**Relay density counted links, not peers.** bitchat uses `peerRegistry.connectedCount`. Bluetooth is dual-role, so one neighbour contributed two links and every room read as twice as crowded as it was. This crossed the dense threshold at three real peers where bitchat crosses at six, and clamped voice and fragment range to five hops early.

**Fragment pacing ignored the transport.** The 25 ms gap exists because the BLE stack drops writes handed over faster than it can make them. The pacer had no idea which transport carried a fragment, so the already-shipped Wi-Fi Aware fast path was paced for a radio it never touched. The same commit also closes a second drain loop that a concurrent transfer could open, doubling the hand-off rate the pacing exists to limit.

## Platform notes

**Android**: `NsdManager`; `MulticastLock`, because Wi-Fi power save drops multicast with the screen off and mDNS is multicast; resolves serialised below API 34, where a second concurrent resolve fails both; `ACCESS_LOCAL_NETWORK` for Android 17.

**iOS**: classic `NWListener` / `NWBrowser`, available since iOS 12, so no availability gate anywhere in the file. Foreground only: iOS has no background mode for a listening socket and reclaims a suspended app's listener.

## Testing

* **142 suites, 2715 tests**: +3 suites and +51 tests here
* Android `compileDebugKotlin` and `minifyReleaseWithR8` both green
* Six simulation scenarios: consent, cross-platform delivery, twelve phones holding exactly eight links each, multi-hop across the ring with no Bluetooth anywhere, client isolation, and teardown on leaving

## Known limits

* **Most guest, hotel, and airport Wi-Fi enables client isolation**, which passes mDNS and drops the connections. It cannot be detected in advance, so the UI reads "No Airhop devices on this network" and never guesses why. Home, office, and hotspot networks generally work
* No background operation on iOS
* Does not reach bitchat, which has no LAN transport on either platform
* Fragments stay 467 bytes; only the gap between them changed

Closes #38